### PR TITLE
Rework `/api/user/data/getUserFlowcharts` endpoint and course cache generation to remove reliance on `apiData`

### DIFF
--- a/src/lib/server/db/course.ts
+++ b/src/lib/server/db/course.ts
@@ -1,0 +1,59 @@
+import { prisma } from '$lib/server/db/prisma';
+import { Prisma } from '@prisma/client';
+import type { APICourse } from '@prisma/client';
+import type { APICourseFull } from '$lib/types';
+
+export async function getCourseData(
+  searchCourses: {
+    id: string;
+    catalog: string;
+  }[]
+): Promise<APICourseFull[]> {
+  const inputCourses = searchCourses.map(
+    (searchCourse) => Prisma.sql`(${Prisma.join([searchCourse.id, searchCourse.catalog])})`
+  );
+
+  // use raw query here bc Prisma doesn't currently use joins
+  // and raw join here is much more efficient than the auto multi-query fetch
+  // for relations that Prisma uses, see here:
+  // https://github.com/prisma/prisma/discussions/8840
+  // https://github.com/prisma/prisma/issues/4997
+
+  // most of the delay that comes from this is network latency and size of data
+  // -- running this query on the db is almost instantaneous
+
+  // fetch the courses from the DB
+  // ternary to make sure we only query if we have courses to query for
+  return inputCourses.length
+    ? (
+        await prisma.$queryRaw<
+          (APICourse & {
+            termSummer: number | null;
+            termFall: number | null;
+            termWinter: number | null;
+            termSpring: number | null;
+          })[]
+        >`SELECT * FROM Course LEFT JOIN TermTypicallyOffered USING (id, catalog) WHERE (id, catalog) IN (${Prisma.join(
+          inputCourses
+        )})`
+      ).map((dbCourseDataRaw) => {
+        const { termSummer, termFall, termWinter, termSpring, ...crs } = dbCourseDataRaw;
+
+        // if no tto data is present, all four entries will be null, so just pick one to check
+        return {
+          ...crs,
+          uscpCourse: !!crs.uscpCourse,
+          gwrCourse: !!crs.gwrCourse,
+          dynamicTerms:
+            termSummer === null
+              ? null
+              : {
+                  termSummer: !!termSummer,
+                  termFall: !!termFall,
+                  termWinter: !!termWinter,
+                  termSpring: !!termSpring
+                }
+        };
+      })
+    : [];
+}

--- a/src/lib/server/schema/getUserFlowchartsSchema.ts
+++ b/src/lib/server/schema/getUserFlowchartsSchema.ts
@@ -2,5 +2,6 @@ import { z } from 'zod';
 
 // validation schema for getUserFlowcharts payload
 export const getUserFlowchartsSchema = z.object({
-  includeCourseCache: z.boolean().default(false)
+  includeCourseCache: z.boolean().default(false),
+  includeProgramMetadata: z.boolean().default(false)
 });

--- a/src/lib/server/util/courseCacheUtil.test.ts
+++ b/src/lib/server/util/courseCacheUtil.test.ts
@@ -269,6 +269,91 @@ describe('generateCourseCacheFlowchart tests', () => {
       )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
   });
+
+  test('generated flowchart course cache only includes catalogs that have courses in them', async () => {
+    const flow1: Flowchart = {
+      hash: '',
+      id: '',
+      lastUpdatedUTC: new Date(),
+      name: '',
+      notes: '',
+      ownerId: '',
+      programId: ['68be11b7-389b-4ebc-9b95-8997e7314497'],
+      startYear: '',
+      termData: [
+        {
+          tIndex: 1,
+          tUnits: '12',
+          courses: [
+            {
+              color: '#FEFD9A',
+              id: 'AGC301'
+            },
+            {
+              color: '#FEFD9A',
+              id: 'AGB301'
+            },
+            {
+              color: '#FEFD9A',
+              id: 'JOUR312'
+            }
+          ]
+        }
+      ],
+      unitTotal: '',
+      version: CURRENT_FLOW_DATA_VERSION,
+      importedId: null,
+      publishedId: null
+    };
+
+    const expectedCourseCache: CourseCache[] = [
+      {
+        catalog: '2015-2017',
+        courses: [
+          {
+            id: 'AGB301',
+            catalog: '2015-2017',
+            displayName: 'Food and Fiber Marketing',
+            units: '4',
+            desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGC301',
+            catalog: '2015-2017',
+            displayName: 'New Media Communication Strategies in Agriculture',
+            units: '4',
+            desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'JOUR312',
+            catalog: '2015-2017',
+            displayName: 'Public Relations',
+            units: '4',
+            desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          }
+        ]
+      }
+    ];
+
+    expect(
+      cloneAndDeleteNestedProperty(
+        await generateCourseCacheFlowchart(flow1, apiDataConfig.apiData.programData),
+        'dynamicTerms'
+      )
+    ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
+  });
 });
 
 describe('generateUserCourseCache tests', () => {
@@ -672,6 +757,91 @@ describe('generateUserCourseCache tests', () => {
     expect(
       cloneAndDeleteNestedProperty(
         await generateUserCourseCache([flow1, flow2], programCache),
+        'dynamicTerms'
+      )
+    ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
+  });
+
+  test('generated user course cache only includes catalogs with courses in them', async () => {
+    const flow1: Flowchart = {
+      hash: '',
+      id: '',
+      lastUpdatedUTC: new Date(),
+      name: '',
+      notes: '',
+      ownerId: '',
+      programId: ['68be11b7-389b-4ebc-9b95-8997e7314497'],
+      startYear: '',
+      termData: [
+        {
+          tIndex: 1,
+          tUnits: '12',
+          courses: [
+            {
+              color: '#FEFD9A',
+              id: 'AGC301'
+            },
+            {
+              color: '#FEFD9A',
+              id: 'AGB301'
+            },
+            {
+              color: '#FEFD9A',
+              id: 'JOUR312'
+            }
+          ]
+        }
+      ],
+      unitTotal: '',
+      version: CURRENT_FLOW_DATA_VERSION,
+      importedId: null,
+      publishedId: null
+    };
+
+    const expectedCourseCache: CourseCache[] = [
+      {
+        catalog: '2015-2017',
+        courses: [
+          {
+            id: 'AGB301',
+            catalog: '2015-2017',
+            displayName: 'Food and Fiber Marketing',
+            units: '4',
+            desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGC301',
+            catalog: '2015-2017',
+            displayName: 'New Media Communication Strategies in Agriculture',
+            units: '4',
+            desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'JOUR312',
+            catalog: '2015-2017',
+            displayName: 'Public Relations',
+            units: '4',
+            desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          }
+        ]
+      }
+    ];
+
+    expect(
+      cloneAndDeleteNestedProperty(
+        await generateUserCourseCache([flow1], apiDataConfig.apiData.programData),
         'dynamicTerms'
       )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));

--- a/src/lib/server/util/courseCacheUtil.test.ts
+++ b/src/lib/server/util/courseCacheUtil.test.ts
@@ -5,14 +5,30 @@ import {
 } from '$lib/server/util/courseCacheUtil';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
 import { cloneAndDeleteNestedProperty } from '../../../../tests/util/testUtil';
+import type { Program } from '@prisma/client';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache } from '$lib/types';
 
 // init API data
 await apiDataConfig.init();
 
+function generateProgramCache(programIds: string[]): Program[] {
+  const programCache = [];
+
+  for (const id of programIds) {
+    // fetch program metadata for this ID
+    const programMetadata = apiDataConfig.apiData.programData.find((prog) => prog.id === id);
+    if (!programMetadata) {
+      throw new Error('programMetadata not found');
+    }
+    programCache.push(programMetadata);
+  }
+
+  return programCache;
+}
+
 describe('generateCourseCacheFlowchart tests', () => {
-  test('generate course cache for flowchart with empty data', () => {
+  test('generate course cache for flowchart with empty data', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -29,15 +45,17 @@ describe('generateCourseCacheFlowchart tests', () => {
       publishedId: null
     };
 
-    const expectedCourseCache: CourseCache[] = apiDataConfig.apiData.catalogs.map((catalog) => ({
-      catalog,
+    const programCache: Program[] = [];
+
+    const expectedCourseCache: CourseCache[] = programCache.map((prog) => ({
+      catalog: prog.catalog,
       courses: []
     }));
 
-    expect(generateCourseCacheFlowchart(flow1)).toStrictEqual(expectedCourseCache);
+    expect(await generateCourseCacheFlowchart(flow1, [])).toStrictEqual(expectedCourseCache);
   });
 
-  test('generate course cache for one flowchart with one catalog', () => {
+  test('generate course cache for one flowchart with one catalog', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -73,54 +91,59 @@ describe('generateCourseCacheFlowchart tests', () => {
       publishedId: null
     };
 
-    const expectedCourseCache: CourseCache[] = apiDataConfig.apiData.catalogs.map((catalog) => ({
-      catalog,
-      courses:
-        catalog !== '2015-2017'
-          ? []
-          : [
-              {
-                id: 'AGC301',
-                catalog: '2015-2017',
-                displayName: 'New Media Communication Strategies in Agriculture',
-                units: '4',
-                desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
-                addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
-                gwrCourse: false,
-                uscpCourse: false,
-                dynamicTerms: null
-              },
-              {
-                id: 'AGB301',
-                catalog: '2015-2017',
-                displayName: 'Food and Fiber Marketing',
-                units: '4',
-                desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
-                addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
-                gwrCourse: false,
-                uscpCourse: false,
-                dynamicTerms: null
-              },
-              {
-                id: 'JOUR312',
-                catalog: '2015-2017',
-                displayName: 'Public Relations',
-                units: '4',
-                desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
-                addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
-                gwrCourse: false,
-                uscpCourse: false,
-                dynamicTerms: null
-              }
-            ]
-    }));
+    // compute program cache for this flowchart
+    const programCache = generateProgramCache(flow1.programId);
+
+    const expectedCourseCache: CourseCache[] = [
+      {
+        catalog: '2015-2017',
+        courses: [
+          {
+            id: 'AGB301',
+            catalog: '2015-2017',
+            displayName: 'Food and Fiber Marketing',
+            units: '4',
+            desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGC301',
+            catalog: '2015-2017',
+            displayName: 'New Media Communication Strategies in Agriculture',
+            units: '4',
+            desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'JOUR312',
+            catalog: '2015-2017',
+            displayName: 'Public Relations',
+            units: '4',
+            desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          }
+        ]
+      }
+    ];
 
     expect(
-      cloneAndDeleteNestedProperty(generateCourseCacheFlowchart(flow1), 'dynamicTerms')
+      cloneAndDeleteNestedProperty(
+        await generateCourseCacheFlowchart(flow1, programCache),
+        'dynamicTerms'
+      )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
   });
 
-  test('generate course cache for one flowchart with two catalogs', () => {
+  test('generate course cache for one flowchart with two catalogs', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -178,87 +201,84 @@ describe('generateCourseCacheFlowchart tests', () => {
       publishedId: null
     };
 
-    const expectedCourseCache: CourseCache[] = apiDataConfig.apiData.catalogs.map((catalog) => ({
-      catalog,
-      courses: []
-    }));
+    // generate program cache for this flowchart
+    const programCache = generateProgramCache(flow1.programId);
 
-    const courseCache1517 = expectedCourseCache.find((cache) => cache.catalog === '2015-2017');
-    const courseCache2226 = expectedCourseCache.find((cache) => cache.catalog === '2022-2026');
-    if (!courseCache1517) {
-      throw new Error('courseCache1517 should be defined');
-    }
-    if (!courseCache2226) {
-      throw new Error('courseCache2226 should be defined');
-    }
+    const courseCache1517 = {
+      catalog: '2015-2017',
+      courses: [
+        {
+          id: 'AGB301',
+          catalog: '2015-2017',
+          displayName: 'Food and Fiber Marketing',
+          units: '4',
+          desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
+          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        },
+        {
+          id: 'AGC301',
+          catalog: '2015-2017',
+          displayName: 'New Media Communication Strategies in Agriculture',
+          units: '4',
+          desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
+          addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        },
+        {
+          id: 'JOUR312',
+          catalog: '2015-2017',
+          displayName: 'Public Relations',
+          units: '4',
+          desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
+          addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        }
+      ]
+    };
 
-    courseCache1517.courses = [
-      {
-        id: 'AGC301',
-        catalog: '2015-2017',
-        displayName: 'New Media Communication Strategies in Agriculture',
-        units: '4',
-        desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
-        addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      },
-      {
-        id: 'AGB301',
-        catalog: '2015-2017',
-        displayName: 'Food and Fiber Marketing',
-        units: '4',
-        desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
-        addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      },
-      {
-        id: 'JOUR312',
-        catalog: '2015-2017',
-        displayName: 'Public Relations',
-        units: '4',
-        desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
-        addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      }
-    ];
+    const courseCache2226 = {
+      catalog: '2022-2026',
+      courses: [
+        {
+          id: 'KINE134',
+          catalog: '2022-2026',
+          displayName: 'Pickleball',
+          units: '1',
+          desc: 'Basic instruction in skill development, knowledge, and desirable attitudes toward physical activity. Fundamental pickleball skills, knowledge, and strategy such that beginning to intermediate levels of play are attained. Enrollment is open to all students. Total limited to 12 units of credit earned in basic instructional KINE courses (KINE 100-176) for non-majors. The following restrictions apply to KINE 100-176: 1) no more than two different activity courses or more than one section of an individual activity course may be taken for credit in any one quarter, 2) a student may not enroll simultaneously in the same quarter for a beginning, intermediate and/or advanced activity course, and 3) any level of an activity course can be repeated only once for credit. Total credit limited to 2 units. Credit/No Credit grading only. 1 activity.\n',
+          addl: 'Term Typically Offered: F, SP\nCR/NC\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        }
+      ]
+    };
 
-    courseCache2226.courses = [
-      {
-        id: 'KINE134',
-        catalog: '2022-2026',
-        displayName: 'Pickleball',
-        units: '1',
-        desc: 'Basic instruction in skill development, knowledge, and desirable attitudes toward physical activity. Fundamental pickleball skills, knowledge, and strategy such that beginning to intermediate levels of play are attained. Enrollment is open to all students. Total limited to 12 units of credit earned in basic instructional KINE courses (KINE 100-176) for non-majors. The following restrictions apply to KINE 100-176: 1) no more than two different activity courses or more than one section of an individual activity course may be taken for credit in any one quarter, 2) a student may not enroll simultaneously in the same quarter for a beginning, intermediate and/or advanced activity course, and 3) any level of an activity course can be repeated only once for credit. Total credit limited to 2 units. Credit/No Credit grading only. 1 activity.\n',
-        addl: 'Term Typically Offered: F, SP\nCR/NC\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      }
-    ];
+    const expectedCourseCache = [courseCache1517, courseCache2226];
 
     expect(
-      cloneAndDeleteNestedProperty(generateCourseCacheFlowchart(flow1), 'dynamicTerms')
+      cloneAndDeleteNestedProperty(
+        await generateCourseCacheFlowchart(flow1, programCache),
+        'dynamicTerms'
+      )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
   });
 });
 
 describe('generateUserCourseCache tests', () => {
-  test('generate user course cache for user with no flowcharts', () => {
-    const expectedCourseCache: CourseCache[] = apiDataConfig.apiData.catalogs.map((catalog) => ({
-      catalog,
-      courses: []
-    }));
+  test('generate user course cache for user with no flowcharts', async () => {
+    const expectedCourseCache: CourseCache[] = [];
 
-    expect(generateUserCourseCache([])).toStrictEqual(expectedCourseCache);
+    expect(await generateUserCourseCache([], [])).toStrictEqual(expectedCourseCache);
   });
 
-  test('generate user course cache for user with one flowchart with empty course data', () => {
+  test('generate user course cache for user with one flowchart with empty course data', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -275,15 +295,12 @@ describe('generateUserCourseCache tests', () => {
       publishedId: null
     };
 
-    const expectedCourseCache: CourseCache[] = apiDataConfig.apiData.catalogs.map((catalog) => ({
-      catalog,
-      courses: []
-    }));
+    const expectedCourseCache: CourseCache[] = [];
 
-    expect(generateUserCourseCache([flow1])).toStrictEqual(expectedCourseCache);
+    expect(await generateUserCourseCache([flow1], [])).toStrictEqual(expectedCourseCache);
   });
 
-  test('generate user course cache for user with one flowchart with oen catalog', () => {
+  test('generate user course cache for user with one flowchart with one catalog', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -319,54 +336,58 @@ describe('generateUserCourseCache tests', () => {
       publishedId: null
     };
 
-    const expectedCourseCache: CourseCache[] = apiDataConfig.apiData.catalogs.map((catalog) => ({
-      catalog,
-      courses:
-        catalog !== '2015-2017'
-          ? []
-          : [
-              {
-                id: 'AGC301',
-                catalog: '2015-2017',
-                displayName: 'New Media Communication Strategies in Agriculture',
-                units: '4',
-                desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
-                addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
-                gwrCourse: false,
-                uscpCourse: false,
-                dynamicTerms: null
-              },
-              {
-                id: 'AGB301',
-                catalog: '2015-2017',
-                displayName: 'Food and Fiber Marketing',
-                units: '4',
-                desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
-                addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
-                gwrCourse: false,
-                uscpCourse: false,
-                dynamicTerms: null
-              },
-              {
-                id: 'JOUR312',
-                catalog: '2015-2017',
-                displayName: 'Public Relations',
-                units: '4',
-                desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
-                addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
-                gwrCourse: false,
-                uscpCourse: false,
-                dynamicTerms: null
-              }
-            ]
-    }));
+    const programCache = generateProgramCache(flow1.programId);
+
+    const expectedCourseCache: CourseCache[] = [
+      {
+        catalog: '2015-2017',
+        courses: [
+          {
+            id: 'AGB301',
+            catalog: '2015-2017',
+            displayName: 'Food and Fiber Marketing',
+            units: '4',
+            desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGC301',
+            catalog: '2015-2017',
+            displayName: 'New Media Communication Strategies in Agriculture',
+            units: '4',
+            desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'JOUR312',
+            catalog: '2015-2017',
+            displayName: 'Public Relations',
+            units: '4',
+            desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          }
+        ]
+      }
+    ];
 
     expect(
-      cloneAndDeleteNestedProperty(generateUserCourseCache([flow1]), 'dynamicTerms')
+      cloneAndDeleteNestedProperty(
+        await generateUserCourseCache([flow1], programCache),
+        'dynamicTerms'
+      )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
   });
 
-  test('generate user course cache for one flowchart with two catalogs', () => {
+  test('generate user course cache for one flowchart with two catalogs', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -424,76 +445,75 @@ describe('generateUserCourseCache tests', () => {
       publishedId: null
     };
 
-    const expectedCourseCache: CourseCache[] = apiDataConfig.apiData.catalogs.map((catalog) => ({
-      catalog,
-      courses: []
-    }));
+    const programCache = generateProgramCache(flow1.programId);
 
-    const courseCache1517 = expectedCourseCache.find((cache) => cache.catalog === '2015-2017');
-    const courseCache2226 = expectedCourseCache.find((cache) => cache.catalog === '2022-2026');
-    if (!courseCache1517) {
-      throw new Error('courseCache1517 should be defined');
-    }
-    if (!courseCache2226) {
-      throw new Error('courseCache2226 should be defined');
-    }
+    const courseCache1517 = {
+      catalog: '2015-2017',
+      courses: [
+        {
+          id: 'AGB301',
+          catalog: '2015-2017',
+          displayName: 'Food and Fiber Marketing',
+          units: '4',
+          desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
+          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        },
+        {
+          id: 'AGC301',
+          catalog: '2015-2017',
+          displayName: 'New Media Communication Strategies in Agriculture',
+          units: '4',
+          desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
+          addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        },
+        {
+          id: 'JOUR312',
+          catalog: '2015-2017',
+          displayName: 'Public Relations',
+          units: '4',
+          desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
+          addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        }
+      ]
+    };
 
-    courseCache1517.courses = [
-      {
-        id: 'AGC301',
-        catalog: '2015-2017',
-        displayName: 'New Media Communication Strategies in Agriculture',
-        units: '4',
-        desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
-        addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      },
-      {
-        id: 'AGB301',
-        catalog: '2015-2017',
-        displayName: 'Food and Fiber Marketing',
-        units: '4',
-        desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
-        addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      },
-      {
-        id: 'JOUR312',
-        catalog: '2015-2017',
-        displayName: 'Public Relations',
-        units: '4',
-        desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
-        addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      }
-    ];
+    const courseCache2226 = {
+      catalog: '2022-2026',
+      courses: [
+        {
+          id: 'KINE134',
+          catalog: '2022-2026',
+          displayName: 'Pickleball',
+          units: '1',
+          desc: 'Basic instruction in skill development, knowledge, and desirable attitudes toward physical activity. Fundamental pickleball skills, knowledge, and strategy such that beginning to intermediate levels of play are attained. Enrollment is open to all students. Total limited to 12 units of credit earned in basic instructional KINE courses (KINE 100-176) for non-majors. The following restrictions apply to KINE 100-176: 1) no more than two different activity courses or more than one section of an individual activity course may be taken for credit in any one quarter, 2) a student may not enroll simultaneously in the same quarter for a beginning, intermediate and/or advanced activity course, and 3) any level of an activity course can be repeated only once for credit. Total credit limited to 2 units. Credit/No Credit grading only. 1 activity.\n',
+          addl: 'Term Typically Offered: F, SP\nCR/NC\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        }
+      ]
+    };
 
-    courseCache2226.courses = [
-      {
-        id: 'KINE134',
-        catalog: '2022-2026',
-        displayName: 'Pickleball',
-        units: '1',
-        desc: 'Basic instruction in skill development, knowledge, and desirable attitudes toward physical activity. Fundamental pickleball skills, knowledge, and strategy such that beginning to intermediate levels of play are attained. Enrollment is open to all students. Total limited to 12 units of credit earned in basic instructional KINE courses (KINE 100-176) for non-majors. The following restrictions apply to KINE 100-176: 1) no more than two different activity courses or more than one section of an individual activity course may be taken for credit in any one quarter, 2) a student may not enroll simultaneously in the same quarter for a beginning, intermediate and/or advanced activity course, and 3) any level of an activity course can be repeated only once for credit. Total credit limited to 2 units. Credit/No Credit grading only. 1 activity.\n',
-        addl: 'Term Typically Offered: F, SP\nCR/NC\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      }
-    ];
+    const expectedCourseCache = [courseCache1517, courseCache2226];
 
     expect(
-      cloneAndDeleteNestedProperty(generateUserCourseCache([flow1]), 'dynamicTerms')
+      cloneAndDeleteNestedProperty(
+        await generateUserCourseCache([flow1], programCache),
+        'dynamicTerms'
+      )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
   });
 
-  test('generate user course cache for user with two flowcharts', () => {
+  test('generate user course cache for user with two flowcharts', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -586,72 +606,74 @@ describe('generateUserCourseCache tests', () => {
       publishedId: null
     };
 
-    const expectedCourseCache: CourseCache[] = apiDataConfig.apiData.catalogs.map((catalog) => ({
-      catalog,
-      courses: []
-    }));
+    // dedup programIds - need to do here but won't happen in prod
+    const programCache = generateProgramCache([
+      ...new Set([...flow1.programId, ...flow2.programId])
+    ]);
 
-    const courseCache1517 = expectedCourseCache.find((cache) => cache.catalog === '2015-2017');
-    const courseCache2226 = expectedCourseCache.find((cache) => cache.catalog === '2022-2026');
-    if (!courseCache1517) {
-      throw new Error('courseCache1517 should be defined');
-    }
-    if (!courseCache2226) {
-      throw new Error('courseCache2226 should be defined');
-    }
+    const courseCache1517 = {
+      catalog: '2015-2017',
+      courses: [
+        {
+          id: 'AGB301',
+          catalog: '2015-2017',
+          displayName: 'Food and Fiber Marketing',
+          units: '4',
+          desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
+          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        },
+        {
+          id: 'AGC301',
+          catalog: '2015-2017',
+          displayName: 'New Media Communication Strategies in Agriculture',
+          units: '4',
+          desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
+          addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        },
+        {
+          id: 'JOUR312',
+          catalog: '2015-2017',
+          displayName: 'Public Relations',
+          units: '4',
+          desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
+          addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        }
+      ]
+    };
 
-    courseCache1517.courses = [
-      {
-        id: 'AGC301',
-        catalog: '2015-2017',
-        displayName: 'New Media Communication Strategies in Agriculture',
-        units: '4',
-        desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
-        addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      },
-      {
-        id: 'AGB301',
-        catalog: '2015-2017',
-        displayName: 'Food and Fiber Marketing',
-        units: '4',
-        desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
-        addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      },
-      {
-        id: 'JOUR312',
-        catalog: '2015-2017',
-        displayName: 'Public Relations',
-        units: '4',
-        desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
-        addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      }
-    ];
+    const courseCache2226 = {
+      catalog: '2022-2026',
+      courses: [
+        {
+          id: 'KINE134',
+          catalog: '2022-2026',
+          displayName: 'Pickleball',
+          units: '1',
+          desc: 'Basic instruction in skill development, knowledge, and desirable attitudes toward physical activity. Fundamental pickleball skills, knowledge, and strategy such that beginning to intermediate levels of play are attained. Enrollment is open to all students. Total limited to 12 units of credit earned in basic instructional KINE courses (KINE 100-176) for non-majors. The following restrictions apply to KINE 100-176: 1) no more than two different activity courses or more than one section of an individual activity course may be taken for credit in any one quarter, 2) a student may not enroll simultaneously in the same quarter for a beginning, intermediate and/or advanced activity course, and 3) any level of an activity course can be repeated only once for credit. Total credit limited to 2 units. Credit/No Credit grading only. 1 activity.\n',
+          addl: 'Term Typically Offered: F, SP\nCR/NC\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        }
+      ]
+    };
 
-    courseCache2226.courses = [
-      {
-        id: 'KINE134',
-        catalog: '2022-2026',
-        displayName: 'Pickleball',
-        units: '1',
-        desc: 'Basic instruction in skill development, knowledge, and desirable attitudes toward physical activity. Fundamental pickleball skills, knowledge, and strategy such that beginning to intermediate levels of play are attained. Enrollment is open to all students. Total limited to 12 units of credit earned in basic instructional KINE courses (KINE 100-176) for non-majors. The following restrictions apply to KINE 100-176: 1) no more than two different activity courses or more than one section of an individual activity course may be taken for credit in any one quarter, 2) a student may not enroll simultaneously in the same quarter for a beginning, intermediate and/or advanced activity course, and 3) any level of an activity course can be repeated only once for credit. Total credit limited to 2 units. Credit/No Credit grading only. 1 activity.\n',
-        addl: 'Term Typically Offered: F, SP\nCR/NC\n',
-        gwrCourse: false,
-        uscpCourse: false,
-        dynamicTerms: null
-      }
-    ];
+    const expectedCourseCache = [courseCache1517, courseCache2226];
 
     expect(
-      cloneAndDeleteNestedProperty(generateUserCourseCache([flow1, flow2]), 'dynamicTerms')
+      cloneAndDeleteNestedProperty(
+        await generateUserCourseCache([flow1, flow2], programCache),
+        'dynamicTerms'
+      )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
   });
 });

--- a/src/lib/server/util/courseCacheUtil.ts
+++ b/src/lib/server/util/courseCacheUtil.ts
@@ -61,7 +61,8 @@ export async function generateCourseCacheFlowchart(
     flowchartCourseCache[idx].courses.push(crs);
   });
 
-  return flowchartCourseCache;
+  // only return caches that have courses in them
+  return flowchartCourseCache.filter((cache) => cache.courses.length);
 }
 
 export async function generateUserCourseCache(
@@ -81,15 +82,22 @@ export async function generateUserCourseCache(
   // TODO: can we optimize this? O(mnp)
   for await (const flow of userFlowcharts) {
     const flowchartCourseCacheData = await generateCourseCacheFlowchart(flow, programCache);
-    flowchartCourseCacheData.forEach((flowchartCourseCacheDataCatalog, i) => {
+    flowchartCourseCacheData.forEach((flowchartCourseCacheDataCatalog) => {
+      const idx = catalogs.findIndex(
+        (catalog) => catalog === flowchartCourseCacheDataCatalog.catalog
+      );
+      if (idx === -1) {
+        throw new Error('courseCacheUtil: mismatch in catalog indexes');
+      }
       flowchartCourseCacheDataCatalog.courses.forEach((crs) => {
-        if (!courseCacheSets[i].has(`${crs.catalog},${crs.id}`)) {
-          courseCacheSets[i].add(`${crs.catalog},${crs.id}`);
-          userCourseCache[i].courses.push(crs);
+        if (!courseCacheSets[idx].has(`${crs.catalog},${crs.id}`)) {
+          courseCacheSets[idx].add(`${crs.catalog},${crs.id}`);
+          userCourseCache[idx].courses.push(crs);
         }
       });
     });
   }
 
-  return userCourseCache;
+  // only return caches that have courses in them
+  return userCourseCache.filter((cache) => cache.courses.length);
 }

--- a/src/lib/server/util/courseCacheUtil.ts
+++ b/src/lib/server/util/courseCacheUtil.ts
@@ -1,13 +1,19 @@
-import { apiData } from '$lib/server/config/apiDataConfig';
+import { Prisma } from '@prisma/client';
+import { prisma } from '$lib/server/db/prisma';
 import { getCatalogFromProgramIDIndex } from '$lib/common/util/courseDataUtilCommon';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
+import type { APICourse, Program } from '@prisma/client';
 import type { APICourseFull, CourseCache } from '$lib/types';
 
-export function generateCourseCacheFlowchart(flowchart: Flowchart): CourseCache[] {
-  const flowchartCourseCache: CourseCache[] = apiData.catalogs.map((catalog) => ({
-    catalog,
-    courses: []
-  }));
+export async function generateCourseCacheFlowchart(
+  flowchart: Flowchart,
+  programCache: Program[]
+): Promise<CourseCache[]> {
+  const catalogs = [...new Set(programCache.map((prog) => prog.catalog))];
+  const courseCacheSets: Set<APICourseFull>[] = catalogs.map(() => new Set());
+
+  // gather courses that need to be fetched
+  const courseIds: Prisma.Sql[] = [];
 
   flowchart.termData.forEach((termData) => {
     termData.courses.forEach((c) => {
@@ -18,51 +24,93 @@ export function generateCourseCacheFlowchart(flowchart: Flowchart): CourseCache[
         const courseCatalog = getCatalogFromProgramIDIndex(
           c.programIdIndex ?? 0,
           flowchart.programId,
-          apiData.programData
+          programCache
         );
 
         if (!courseCatalog) {
           throw new Error('courseCacheUtil: undefined courseCatalog');
         }
 
-        // get the associated course data
-        const courseMetadata = apiData.courseData
-          .find((cache) => cache.catalog === courseCatalog)
-          ?.courses.find((crs) => crs.id === c.id);
-
-        const catalogCourseCache = flowchartCourseCache.find(
-          (cache) => cache.catalog === courseCatalog
-        )?.courses;
-
-        if (!catalogCourseCache) {
-          throw new Error('courseCacheUtil: undefined catalog in course cache');
-        }
-
-        if (courseMetadata) {
-          catalogCourseCache.push(courseMetadata);
-        }
+        courseIds.push(Prisma.sql`(${Prisma.join([c.id, courseCatalog])})`);
       }
     });
   });
 
+  // TODO: move this logic to an API route
+  // fetch the courses from the DB
+  // ternary to make sure we only query if we have courses to query for
+  const courses: APICourseFull[] = courseIds.length
+    ? (
+        await prisma.$queryRaw<
+          (APICourse & {
+            termSummer: number | null;
+            termFall: number | null;
+            termWinter: number | null;
+            termSpring: number | null;
+          })[]
+        >`SELECT * FROM Course LEFT JOIN TermTypicallyOffered USING (id, catalog) WHERE (id, catalog) IN (${Prisma.join(
+          courseIds
+        )})`
+      ).map((dbCourseDataRaw) => {
+        const { termSummer, termFall, termWinter, termSpring, ...crs } = dbCourseDataRaw;
+
+        // if no tto data is present, all four entries will be null, so just pick one to check
+        return {
+          ...crs,
+          uscpCourse: !!crs.uscpCourse,
+          gwrCourse: !!crs.gwrCourse,
+          dynamicTerms:
+            termSummer === null
+              ? null
+              : {
+                  termSummer: !!termSummer,
+                  termFall: !!termFall,
+                  termWinter: !!termWinter,
+                  termSpring: !!termSpring
+                }
+        };
+      })
+    : [];
+
+  // map courses to course cache
+  courses.forEach((crs) => {
+    const idx = catalogs.findIndex((catalog) => catalog === crs.catalog);
+    if (idx === -1) {
+      throw new Error('courseCacheUtil: undefined catalog in courseCache Set');
+    }
+
+    courseCacheSets[idx].add(crs);
+  });
+
+  const flowchartCourseCache: CourseCache[] = [];
+  catalogs.forEach((catalog, i) =>
+    flowchartCourseCache.push({
+      catalog,
+      courses: Array.from(courseCacheSets[i])
+    })
+  );
   return flowchartCourseCache;
 }
 
-export function generateUserCourseCache(userFlowcharts: Flowchart[]): CourseCache[] {
-  const courseCacheSets: Set<APICourseFull>[] = apiData.catalogs.map(() => new Set());
+export async function generateUserCourseCache(
+  userFlowcharts: Flowchart[],
+  programCache: Program[]
+): Promise<CourseCache[]> {
+  const catalogs = [...new Set(programCache.map((prog) => prog.catalog))];
+  const courseCacheSets: Set<APICourseFull>[] = catalogs.map(() => new Set());
 
   // TODO: can we optimize this? O(n^3)
-  userFlowcharts.forEach((flow) => {
-    const flowchartCourseCacheData = generateCourseCacheFlowchart(flow);
+  for await (const flow of userFlowcharts) {
+    const flowchartCourseCacheData = await generateCourseCacheFlowchart(flow, programCache);
     flowchartCourseCacheData.forEach((flowchartCourseCacheDataCatalog, i) => {
       flowchartCourseCacheDataCatalog.courses.forEach((crs) => {
         courseCacheSets[i].add(crs);
       });
     });
-  });
+  }
 
   const userCourseCache: CourseCache[] = [];
-  apiData.catalogs.forEach((catalog, i) =>
+  catalogs.forEach((catalog, i) =>
     userCourseCache.push({
       catalog,
       courses: Array.from(courseCacheSets[i])

--- a/src/routes/api/data/generateFlowchart/+server.ts
+++ b/src/routes/api/data/generateFlowchart/+server.ts
@@ -1,4 +1,5 @@
 import { json } from '@sveltejs/kit';
+import { apiData } from '$lib/server/config/apiDataConfig';
 import { initLogger } from '$lib/common/config/loggerConfig';
 import { generateFlowchart } from '$lib/server/util/flowDataUtil';
 import { generateFlowchartSchema } from '$lib/server/schema/generateFlowchartSchema';
@@ -40,7 +41,8 @@ export const GET: RequestHandler = async ({ locals, url }) => {
         message: 'Flowchart successfully generated.',
         generatedFlowchart,
         ...(parseResults.data.generateCourseCache && {
-          courseCache: generateCourseCacheFlowchart(generatedFlowchart)
+          // TODO: move away from this: https://github.com/polyflowbuilder/polyflowbuilder/issues/2
+          courseCache: await generateCourseCacheFlowchart(generatedFlowchart, apiData.programData)
         })
       });
     } else {

--- a/src/routes/api/user/data/getUserFlowcharts/+server.ts
+++ b/src/routes/api/user/data/getUserFlowcharts/+server.ts
@@ -3,6 +3,8 @@ import { initLogger } from '$lib/common/config/loggerConfig';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
 import { generateUserCourseCache } from '$lib/server/util/courseCacheUtil';
 import { getUserFlowchartsSchema } from '$lib/server/schema/getUserFlowchartsSchema';
+import type { Program } from '@prisma/client';
+import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { RequestHandler } from '@sveltejs/kit';
 
 const logger = initLogger('APIRouteHandler (/api/user/data/getUserFlowcharts)');
@@ -32,21 +34,26 @@ export const GET: RequestHandler = async ({ locals, url }) => {
     });
     if (parseResults.success) {
       // get user data
-      const userFlowchartsData = await getUserFlowcharts(
-        locals.session.id,
-        [],
-        parseResults.data.includeProgramMetadata
-      );
-      const userFlowcharts = userFlowchartsData.map(({ flowchart }) => flowchart);
+      const userFlowchartsData = await getUserFlowcharts(locals.session.id, [], true);
+      const flowcharts: Flowchart[] = [];
+      const programMetadata: Program[] = [];
+
+      userFlowchartsData.forEach((data) => {
+        flowcharts.push(data.flowchart);
+        // to satisfy type checking
+        if (data.programMetadata) {
+          programMetadata.push(...data.programMetadata);
+        }
+      });
 
       return json({
         message: 'User flowchart retrieval successful.',
-        flowcharts: userFlowcharts,
+        flowcharts,
         ...(parseResults.data.includeCourseCache && {
-          courseCache: generateUserCourseCache(userFlowcharts)
+          courseCache: await generateUserCourseCache(flowcharts, programMetadata)
         }),
         ...(parseResults.data.includeProgramMetadata && {
-          programMetadata: userFlowchartsData.map(({ programMetadata }) => programMetadata)
+          programMetadata
         })
       });
     } else {

--- a/src/routes/flows/+page.ts
+++ b/src/routes/flows/+page.ts
@@ -1,3 +1,4 @@
+import type { Program } from '@prisma/client';
 import type { PageLoad } from './$types';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache } from '$lib/types';
@@ -5,7 +6,9 @@ import type { CourseCache } from '$lib/types';
 export const load: PageLoad = async ({ fetch }) => {
   // get flowcharts with course cache
   // if we include multiple requests, make sure they are using the promise streaming SK flow
-  const userFlowcharts = await fetch('/api/user/data/getUserFlowcharts?includeCourseCache=true');
+  const userFlowcharts = await fetch(
+    '/api/user/data/getUserFlowcharts?includeCourseCache=true&includeProgramMetadata=true'
+  );
   if (!userFlowcharts.ok) {
     // need this explicitly instead of null to ensure types are inferred correctly
     return undefined;
@@ -14,11 +17,13 @@ export const load: PageLoad = async ({ fetch }) => {
       message: string;
       flowcharts: Flowchart[];
       courseCache: CourseCache[];
+      programMetadata: Program[][];
     };
 
     return {
       flowcharts: userFlowchartsJson.flowcharts,
-      courseCache: userFlowchartsJson.courseCache
+      courseCache: userFlowchartsJson.courseCache,
+      programMetadata: userFlowchartsJson.programMetadata
     };
   }
 };

--- a/tests/api/generateFlowchartApiTests.test.ts
+++ b/tests/api/generateFlowchartApiTests.test.ts
@@ -1114,28 +1114,15 @@ const responsePayload1 = {
           uscpCourse: false
         }
       ]
-    },
-    {
-      catalog: '2017-2019',
-      courses: []
-    },
-    {
-      catalog: '2019-2020',
-      courses: []
-    },
-    {
-      catalog: '2020-2021',
-      courses: []
-    },
-    {
-      catalog: '2021-2022',
-      courses: []
-    },
-    {
-      catalog: '2022-2026',
-      courses: []
     }
-  ]
+  ] // sort to ensure order of items doesn't matter in cache
+    .map((cache) => {
+      return {
+        catalog: cache.catalog,
+        courses: cache.courses.sort((a, b) => a.id.localeCompare(b.id))
+      };
+    })
+    .sort((a, b) => a.catalog.localeCompare(b.catalog))
 };
 
 const responsePayload2 = {
@@ -2289,22 +2276,6 @@ const responsePayload2 = {
       ]
     },
     {
-      catalog: '2017-2019',
-      courses: []
-    },
-    {
-      catalog: '2019-2020',
-      courses: []
-    },
-    {
-      catalog: '2020-2021',
-      courses: []
-    },
-    {
-      catalog: '2021-2022',
-      courses: []
-    },
-    {
       catalog: '2022-2026',
       courses: [
         {
@@ -2620,6 +2591,14 @@ const responsePayload2 = {
       ]
     }
   ]
+    // sort to ensure order of items doesn't matter in cache
+    .map((cache) => {
+      return {
+        catalog: cache.catalog,
+        courses: cache.courses.sort((a, b) => a.id.localeCompare(b.id))
+      };
+    })
+    .sort((a, b) => a.catalog.localeCompare(b.catalog))
 };
 
 test.describe('generate flowchart api input tests', () => {
@@ -2971,7 +2950,15 @@ test.describe('generate flowchart api output tests', () => {
         'hash',
         'lastUpdatedUTC'
       ]),
+      // sort to ensure order of items doesn't matter in cache
       courseCache: resData.courseCache
+        ?.map((cache) => {
+          return {
+            catalog: cache.catalog,
+            courses: cache.courses.sort((a, b) => a.id.localeCompare(b.id))
+          };
+        })
+        .sort((a, b) => a.catalog.localeCompare(b.catalog))
     };
 
     // remove dynamicTerms as this can change over time
@@ -3114,7 +3101,15 @@ test.describe('generate flowchart api output tests', () => {
         'hash',
         'lastUpdatedUTC'
       ]),
+      // sort to ensure order of items doesn't matter in cache
       courseCache: resData.courseCache
+        ?.map((cache) => {
+          return {
+            catalog: cache.catalog,
+            courses: cache.courses.sort((a, b) => a.id.localeCompare(b.id))
+          };
+        })
+        .sort((a, b) => a.catalog.localeCompare(b.catalog))
     };
 
     // remove dynamicTerms as this can change over time

--- a/tests/api/getUserFlowchartsTests.test.ts
+++ b/tests/api/getUserFlowchartsTests.test.ts
@@ -64,32 +64,7 @@ test.describe('getUserFlowcharts API tests', () => {
     const expectedResponseBody = {
       message: 'User flowchart retrieval successful.',
       flowcharts: [],
-      courseCache: [
-        {
-          catalog: '2015-2017',
-          courses: []
-        },
-        {
-          catalog: '2017-2019',
-          courses: []
-        },
-        {
-          catalog: '2019-2020',
-          courses: []
-        },
-        {
-          catalog: '2020-2021',
-          courses: []
-        },
-        {
-          catalog: '2021-2022',
-          courses: []
-        },
-        {
-          catalog: '2022-2026',
-          courses: []
-        }
-      ]
+      courseCache: []
     };
 
     expect(res.status()).toBe(200);
@@ -263,6 +238,17 @@ test.describe('getUserFlowcharts API tests', () => {
           catalog: '2015-2017',
           courses: [
             {
+              id: 'CHEM124',
+              catalog: '2015-2017',
+              displayName: 'General Chemistry for Physical Science and Engineering I',
+              units: '4',
+              desc: 'Stoichiometry, thermochemistry, atomic structure, bonding, solid-state structures, intermolecular forces, and foundational principles of organic chemistry.  Not open to students with credit in CHEM 127.  Credit will be granted in only one of the following courses:  CHEM 110, CHEM 111, CHEM 124.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
+              addl: 'GE Area B4; GE Area B3\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Passing score on ELM, or an ELM exemption, or credit in MATH 104. Recommended: High school chemistry or equivalent.\n',
+              gwrCourse: false,
+              uscpCourse: false,
+              dynamicTerms: null
+            },
+            {
               id: 'CPE101',
               catalog: '2015-2017',
               displayName: 'Fundamentals of Computer Science I',
@@ -283,17 +269,6 @@ test.describe('getUserFlowcharts API tests', () => {
               gwrCourse: false,
               uscpCourse: false,
               dynamicTerms: null
-            },
-            {
-              id: 'CHEM124',
-              catalog: '2015-2017',
-              displayName: 'General Chemistry for Physical Science and Engineering I',
-              units: '4',
-              desc: 'Stoichiometry, thermochemistry, atomic structure, bonding, solid-state structures, intermolecular forces, and foundational principles of organic chemistry.  Not open to students with credit in CHEM 127.  Credit will be granted in only one of the following courses:  CHEM 110, CHEM 111, CHEM 124.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
-              addl: 'GE Area B4; GE Area B3\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Passing score on ELM, or an ELM exemption, or credit in MATH 104. Recommended: High school chemistry or equivalent.\n',
-              gwrCourse: false,
-              uscpCourse: false,
-              dynamicTerms: null
             }
           ]
         },
@@ -301,23 +276,23 @@ test.describe('getUserFlowcharts API tests', () => {
           catalog: '2017-2019',
           courses: [
             {
-              id: 'AGC301',
-              catalog: '2017-2019',
-              displayName: 'New Media Communication Strategies in Agriculture',
-              units: '4',
-              desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
-              addl: 'Term Typically Offered: W\nPrerequisite: Junior standing. Recommended: JOUR 203, JOUR 205.\n',
-              gwrCourse: false,
-              uscpCourse: false,
-              dynamicTerms: null
-            },
-            {
               id: 'AGB301',
               catalog: '2017-2019',
               displayName: 'Food and Fiber Marketing',
               units: '4',
               desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
               addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
+              gwrCourse: false,
+              uscpCourse: false,
+              dynamicTerms: null
+            },
+            {
+              id: 'AGC301',
+              catalog: '2017-2019',
+              displayName: 'New Media Communication Strategies in Agriculture',
+              units: '4',
+              desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
+              addl: 'Term Typically Offered: W\nPrerequisite: Junior standing. Recommended: JOUR 203, JOUR 205.\n',
               gwrCourse: false,
               uscpCourse: false,
               dynamicTerms: null
@@ -334,22 +309,6 @@ test.describe('getUserFlowcharts API tests', () => {
               dynamicTerms: null
             }
           ]
-        },
-        {
-          catalog: '2019-2020',
-          courses: []
-        },
-        {
-          catalog: '2020-2021',
-          courses: []
-        },
-        {
-          catalog: '2021-2022',
-          courses: []
-        },
-        {
-          catalog: '2022-2026',
-          courses: []
         }
       ]
     };


### PR DESCRIPTION
This PR reworks the `/api/user/data/getUserFlowcharts` endpoint to return flowchart program information from the DB instead of relying on the "program cache" on the backend (task 1 of #2) and updates the caller's handling of the response data from this endpoint. This removes the reliance on the monolithic `apiData` object on the backend for this route.

To accomplish this change, the course cache generation utilities (`generateCourseCacheFlowchart` and `generateUserCourseCache`) were reworked to use the fetched program information instead of the monolithic `apiData` object. These changes now mean that the course information has to be fetched from the DB as well, with one DB call made per flowchart.

Additionally, these utilities now only return caches that have courses in them, versus returning caches for all catalogs regardless of whether they contained courses. The existing strategy had no advantages, would not scale well given more catalogs, and was wasteful of bandwidth.

Tests were modified and added to accommodate these changes.