### PR TITLE
Rework `/api/data/generateFlowchart` endpoint to remove reliance on `apiData`

### DIFF
--- a/src/lib/server/db/templateFlowchart.ts
+++ b/src/lib/server/db/templateFlowchart.ts
@@ -1,19 +1,35 @@
 import { prisma } from '$lib/server/db/prisma';
 import { initLogger } from '$lib/common/config/loggerConfig';
-import type { TemplateFlowchart } from '@prisma/client';
+import type { Program, TemplateFlowchart } from '@prisma/client';
 
 const logger = initLogger('DB/TemplateFlowchart');
 
-export async function getTemplateFlowcharts(programId: string[]): Promise<TemplateFlowchart[]> {
+export async function getTemplateFlowcharts(programId: string[]): Promise<
+  {
+    flowchart: TemplateFlowchart;
+    programMetadata: Program;
+  }[]
+> {
   const res = await prisma.templateFlowchart.findMany({
     where: {
       programId: {
         in: programId
       }
+    },
+    include: {
+      programIdRelation: true
     }
+  });
+
+  const resConverted = res.map((templateFlowData) => {
+    const { programIdRelation: programMetadata, ...templateFlowchart } = templateFlowData;
+    return {
+      flowchart: templateFlowchart,
+      programMetadata
+    };
   });
 
   logger.info(`Successfully got template flowchart(s) ${programId.join(',')}`);
 
-  return res;
+  return resConverted;
 }

--- a/src/lib/server/db/templateFlowchart.ts
+++ b/src/lib/server/db/templateFlowchart.ts
@@ -1,35 +1,52 @@
 import { prisma } from '$lib/server/db/prisma';
+import { Prisma } from '@prisma/client';
 import { initLogger } from '$lib/common/config/loggerConfig';
 import type { Program, TemplateFlowchart } from '@prisma/client';
 
 const logger = initLogger('DB/TemplateFlowchart');
 
-export async function getTemplateFlowcharts(programId: string[]): Promise<
+export async function getTemplateFlowcharts(programIds: string[]): Promise<
   {
     flowchart: TemplateFlowchart;
     programMetadata: Program;
   }[]
 > {
-  const res = await prisma.templateFlowchart.findMany({
-    where: {
-      programId: {
-        in: programId
-      }
-    },
-    include: {
-      programIdRelation: true
-    }
-  });
+  // use raw query here bc Prisma doesn't currently use joins
+  // and raw join here is much more efficient than the auto multi-query fetch
+  // for relations that Prisma uses, see here:
+  // https://github.com/prisma/prisma/discussions/8840
+  // https://github.com/prisma/prisma/issues/4997
 
-  const resConverted = res.map((templateFlowData) => {
-    const { programIdRelation: programMetadata, ...templateFlowchart } = templateFlowData;
+  const res = (
+    await prisma.$queryRaw<
+      (TemplateFlowchart & Program)[]
+    >`SELECT * FROM TemplateFlowchart INNER JOIN Program ON programId = id WHERE programId IN (${Prisma.join(
+      programIds
+    )})`
+  ).map((resEntry) => {
+    const flowchart: TemplateFlowchart = {
+      programId: resEntry.programId,
+      termData: resEntry.termData,
+      flowUnitTotal: resEntry.flowUnitTotal,
+      notes: resEntry.notes,
+      version: resEntry.version
+    };
+    const programMetadata: Program = {
+      id: resEntry.id,
+      catalog: resEntry.catalog,
+      majorName: resEntry.majorName,
+      concName: resEntry.concName,
+      code: resEntry.code,
+      dataLink: resEntry.dataLink
+    };
+
     return {
-      flowchart: templateFlowchart,
+      flowchart,
       programMetadata
     };
   });
 
-  logger.info(`Successfully got template flowchart(s) ${programId.join(',')}`);
+  logger.info(`Successfully got template flowchart(s) ${programIds.join(',')}`);
 
-  return resConverted;
+  return res;
 }

--- a/src/lib/server/util/flowDataUtil.ts
+++ b/src/lib/server/util/flowDataUtil.ts
@@ -122,7 +122,7 @@ export async function generateFlowchart(data: GenerateFlowchartData): Promise<{
   // compute hash
   generatedFlowchart.hash = generateFlowHash(generatedFlowchart);
 
-  // safe to map programMetadata here (re: dedup) request is validated to have
+  // safe to map programMetadata here (re: dedup) as request is validated to have
   // unique programIds before generating
   return {
     flowchart: generatedFlowchart,

--- a/src/routes/api/data/generateFlowchart/+server.ts
+++ b/src/routes/api/data/generateFlowchart/+server.ts
@@ -1,5 +1,4 @@
 import { json } from '@sveltejs/kit';
-import { apiData } from '$lib/server/config/apiDataConfig';
 import { initLogger } from '$lib/common/config/loggerConfig';
 import { generateFlowchart } from '$lib/server/util/flowDataUtil';
 import { generateFlowchartSchema } from '$lib/server/schema/generateFlowchartSchema';
@@ -35,14 +34,15 @@ export const GET: RequestHandler = async ({ locals, url }) => {
         : undefined
     });
     if (parseResults.success) {
-      const generatedFlowchart = await generateFlowchart(parseResults.data);
+      const { flowchart: generatedFlowchart, programMetadata } = await generateFlowchart(
+        parseResults.data
+      );
 
       return json({
         message: 'Flowchart successfully generated.',
         generatedFlowchart,
         ...(parseResults.data.generateCourseCache && {
-          // TODO: move away from this: https://github.com/polyflowbuilder/polyflowbuilder/issues/2
-          courseCache: await generateCourseCacheFlowchart(generatedFlowchart, apiData.programData)
+          courseCache: await generateCourseCacheFlowchart(generatedFlowchart, programMetadata)
         })
       });
     } else {


### PR DESCRIPTION
This PR reworks the `/api/data/generateFlowchart` endpoint to remove its reliance on the monolithic `apiData` object on the backend (introduced by #3).

Current tests are passing and no additional tests were added.