### PR TITLE
Create `/api/data/getAvailableStartYears` endpoint

### DIFF
--- a/src/lib/server/db/startYear.ts
+++ b/src/lib/server/db/startYear.ts
@@ -1,0 +1,5 @@
+import { prisma } from '$lib/server/db/prisma';
+
+export async function getStartYears(): Promise<string[]> {
+  return (await prisma.startYear.findMany()).map((startYear) => startYear.year);
+}

--- a/src/routes/api/data/getAvailableStartYears/+server.ts
+++ b/src/routes/api/data/getAvailableStartYears/+server.ts
@@ -1,0 +1,38 @@
+import { json } from '@sveltejs/kit';
+import { initLogger } from '$lib/common/config/loggerConfig';
+import { getStartYears } from '$lib/server/db/startYear';
+import type { RequestHandler } from '@sveltejs/kit';
+
+const logger = initLogger('APIRouteHandler (/api/data/getAvailableStartYears)');
+
+export const GET: RequestHandler = async ({ locals }) => {
+  try {
+    // ensure request is authenticated
+    if (!locals.session) {
+      return json(
+        {
+          message: 'Request must be authenticated.'
+        },
+        {
+          status: 401
+        }
+      );
+    }
+
+    // return the data
+    return json({
+      startYears: await getStartYears()
+    });
+  } catch (error) {
+    logger.error('an internal error occurred', error);
+    return json(
+      {
+        message:
+          'An error occurred while fetching available start years, please try again a bit later.'
+      },
+      {
+        status: 500
+      }
+    );
+  }
+};

--- a/tests/api/getAvailableStartYearsTests.test.ts
+++ b/tests/api/getAvailableStartYearsTests.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+import { performLoginBackend } from 'tests/util/userTestUtil';
+import { createUser, deleteUser } from '$lib/server/db/user';
+
+const GET_AVAILABLE_START_YEARS_API_TESTS_EMAIL =
+  'pfb_test_getAvailableStartYearsAPI_playwright@test.com';
+
+test.describe('getAvailableStartYears tests', () => {
+  test.beforeAll(async () => {
+    // create account
+    await createUser({
+      email: GET_AVAILABLE_START_YEARS_API_TESTS_EMAIL,
+      username: 'test',
+      password: 'test'
+    });
+  });
+
+  test.afterAll(async () => {
+    // delete account
+    await deleteUser(GET_AVAILABLE_START_YEARS_API_TESTS_EMAIL);
+  });
+
+  test('authenticated request is successful', async ({ request }) => {
+    await performLoginBackend(request, GET_AVAILABLE_START_YEARS_API_TESTS_EMAIL, 'test');
+
+    const res = await request.get('/api/data/getAvailableStartYears');
+    const resData = (await res.json()) as {
+      startYears: string[];
+    };
+
+    expect(res.status()).toBe(200);
+    expect(resData).toHaveProperty('startYears');
+    expect(resData.startYears.length).toBeTruthy();
+  });
+
+  test('401 case handled properly', async ({ request }) => {
+    const res = await request.get('/api/data/getAvailableStartYears');
+    const resData = (await res.json()) as unknown;
+
+    expect(res.ok()).toBeFalsy();
+    expect(res.status()).toBe(401);
+    expect(resData).toStrictEqual({
+      message: 'Request must be authenticated.'
+    });
+  });
+
+  // TODO: add 500 case
+});


### PR DESCRIPTION
This PR is to create a new endpoint, `/api/data/getAvailableStartYears`, that returns the valid start years for a flowchart.

This is part of task 3 of #2.

New tests were created for this API.