### PR TITLE
Create `/api/data/getAvailableCatalogs` endpoint

### DIFF
--- a/src/lib/server/db/catalog.ts
+++ b/src/lib/server/db/catalog.ts
@@ -1,0 +1,5 @@
+import { prisma } from '$lib/server/db/prisma';
+
+export async function getCatalogs(): Promise<string[]> {
+  return (await prisma.catalog.findMany()).map(({ catalog }) => catalog);
+}

--- a/src/routes/api/data/getAvailableCatalogs/+server.ts
+++ b/src/routes/api/data/getAvailableCatalogs/+server.ts
@@ -1,0 +1,38 @@
+import { json } from '@sveltejs/kit';
+import { initLogger } from '$lib/common/config/loggerConfig';
+import { getCatalogs } from '$lib/server/db/catalog';
+import type { RequestHandler } from '@sveltejs/kit';
+
+const logger = initLogger('APIRouteHandler (/api/data/getAvailableCatalogs)');
+
+export const GET: RequestHandler = async ({ locals }) => {
+  try {
+    // ensure request is authenticated
+    if (!locals.session) {
+      return json(
+        {
+          message: 'Request must be authenticated.'
+        },
+        {
+          status: 401
+        }
+      );
+    }
+
+    // return the data
+    return json({
+      catalogs: await getCatalogs()
+    });
+  } catch (error) {
+    logger.error('an internal error occurred', error);
+    return json(
+      {
+        message:
+          'An error occurred while fetching available catalogs, please try again a bit later.'
+      },
+      {
+        status: 500
+      }
+    );
+  }
+};

--- a/tests/api/getAvailableCatalogsTests.test.ts
+++ b/tests/api/getAvailableCatalogsTests.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+import { performLoginBackend } from 'tests/util/userTestUtil';
+import { createUser, deleteUser } from '$lib/server/db/user';
+
+const GET_AVAILABLE_CATALOGS_API_TESTS_EMAIL =
+  'pfb_test_getAvailableCatalogsAPI_playwright@test.com';
+
+test.describe('getAvailableStartYears tests', () => {
+  test.beforeAll(async () => {
+    // create account
+    await createUser({
+      email: GET_AVAILABLE_CATALOGS_API_TESTS_EMAIL,
+      username: 'test',
+      password: 'test'
+    });
+  });
+
+  test.afterAll(async () => {
+    // delete account
+    await deleteUser(GET_AVAILABLE_CATALOGS_API_TESTS_EMAIL);
+  });
+
+  test('authenticated request is successful', async ({ request }) => {
+    await performLoginBackend(request, GET_AVAILABLE_CATALOGS_API_TESTS_EMAIL, 'test');
+
+    const res = await request.get('/api/data/getAvailableCatalogs');
+    const resData = (await res.json()) as {
+      catalogs: string[];
+    };
+
+    expect(res.status()).toBe(200);
+    expect(resData).toHaveProperty('catalogs');
+    expect(resData.catalogs.length).toBeTruthy();
+  });
+
+  test('401 case handled properly', async ({ request }) => {
+    const res = await request.get('/api/data/getAvailableCatalogs');
+    const resData = (await res.json()) as unknown;
+
+    expect(res.ok()).toBeFalsy();
+    expect(res.status()).toBe(401);
+    expect(resData).toStrictEqual({
+      message: 'Request must be authenticated.'
+    });
+  });
+
+  // TODO: add 500 case
+});


### PR DESCRIPTION
This PR is to create a new endpoint, `/api/data/getAvailableCatalogs`, that returns the valid catalogs for a flowchart.

This is part of task 3 #2.

New tests were created for this API.