### PR TITLE
Create `/api/data/queryAvailablePrograms` endpoint

### DIFF
--- a/src/lib/server/db/program.ts
+++ b/src/lib/server/db/program.ts
@@ -1,0 +1,40 @@
+import { prisma } from '$lib/server/db/prisma';
+import type { Program } from '@prisma/client';
+
+export async function getProgramsFromIds(programIds: string[]): Promise<Program[]> {
+  return await prisma.program.findMany({
+    where: {
+      id: {
+        in: programIds
+      }
+    }
+  });
+}
+
+export async function getProgramMajorsFromCatalog(catalog: string): Promise<string[]> {
+  // use raw query bc Prisma by default uses SELECT + in-memory post-processing
+  // for distinct instead of SELECT DISTINCT (which is not ideal in our case)
+  // see https://www.prisma.io/docs/concepts/components/prisma-client/aggregation-grouping-summarizing#select-distinct
+  return (
+    await prisma.$queryRaw<
+      {
+        majorName: string;
+      }[]
+    >`SELECT DISTINCT majorName FROM Program WHERE catalog = ${catalog} ORDER BY majorName ASC;`
+  ).map(({ majorName }) => majorName);
+}
+
+export async function getProgramsFromCatalogMajor(
+  catalog: string,
+  majorName: string
+): Promise<Program[]> {
+  return await prisma.program.findMany({
+    where: {
+      catalog,
+      majorName
+    },
+    orderBy: {
+      concName: 'asc'
+    }
+  });
+}

--- a/src/lib/server/schema/queryAvailableProgramsSchema.ts
+++ b/src/lib/server/schema/queryAvailableProgramsSchema.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+// validation schema for api/data/queryAvailablePrograms endpoint
+// currently only support the following query types:
+// 1. id
+// 2. catalog+majorName
+export const queryAvailableProgramsValidationSchema = z.union(
+  [
+    z
+      .object({
+        id: z
+          .string({
+            required_error: 'Program unique ID is required.'
+          })
+          .uuid('Invalid format for program unique ID.')
+      })
+      .strict(),
+    z
+      .object({
+        majorName: z
+          .string({
+            required_error: 'Major name is required.'
+          })
+          .min(1, 'Major name must not be empty.'),
+        catalog: z
+          .string({
+            required_error: 'Catalog is required.'
+          })
+          .refine((catalog) => {
+            const parts = catalog.split('-').map((part) => Number(part));
+            return !isNaN(parts[0]) && !isNaN(parts[1]) && parts[1] > parts[0];
+          }, 'Invalid catalog format.')
+      })
+      .strict()
+  ],
+  {
+    errorMap: (issue, ctx) => {
+      if (issue.code === z.ZodIssueCode.invalid_union) {
+        return {
+          message: 'Invalid query for available programs.'
+        };
+      }
+      return {
+        message: ctx.defaultError
+      };
+    }
+  }
+);

--- a/src/lib/server/schema/queryAvailableProgramsSchema.ts
+++ b/src/lib/server/schema/queryAvailableProgramsSchema.ts
@@ -4,45 +4,53 @@ import { z } from 'zod';
 // currently only support the following query types:
 // 1. id
 // 2. catalog+majorName
-export const queryAvailableProgramsValidationSchema = z.union(
-  [
-    z
-      .object({
-        id: z
-          .string({
-            required_error: 'Program unique ID is required.'
-          })
-          .uuid('Invalid format for program unique ID.')
-      })
-      .strict(),
-    z
-      .object({
-        majorName: z
-          .string({
-            required_error: 'Major name is required.'
-          })
-          .min(1, 'Major name must not be empty.'),
-        catalog: z
-          .string({
-            required_error: 'Catalog is required.'
-          })
-          .refine((catalog) => {
-            const parts = catalog.split('-').map((part) => Number(part));
-            return !isNaN(parts[0]) && !isNaN(parts[1]) && parts[1] > parts[0];
-          }, 'Invalid catalog format.')
-      })
-      .strict()
-  ],
-  {
-    errorMap: (issue, ctx) => {
-      if (issue.code === z.ZodIssueCode.invalid_union) {
-        return {
+export const queryAvailableProgramsSchema = z.object({
+  query: z.union(
+    [
+      z
+        .object({
+          id: z
+            .string({
+              required_error: 'Program unique ID is required.'
+            })
+            .uuid('Invalid format for program unique ID.')
+        })
+        .strict({
           message: 'Invalid query for available programs.'
+        }),
+      z
+        .object({
+          majorName: z
+            .string({
+              required_error: 'Major name is required.'
+            })
+            .min(1, 'Major name must not be empty.'),
+          catalog: z
+            .string({
+              required_error: 'Catalog is required.'
+            })
+            .refine((catalog) => {
+              const parts = catalog.split('-').map((part) => Number(part));
+              return (
+                catalog.length === 9 && !isNaN(parts[0]) && !isNaN(parts[1]) && parts[1] > parts[0]
+              );
+            }, 'Invalid catalog format.')
+        })
+        .strict({
+          message: 'Invalid query for available programs.'
+        })
+    ],
+    {
+      errorMap: (issue, ctx) => {
+        if (issue.code === z.ZodIssueCode.invalid_union) {
+          return {
+            message: 'Invalid query for available programs.'
+          };
+        }
+        return {
+          message: ctx.defaultError
         };
       }
-      return {
-        message: ctx.defaultError
-      };
     }
-  }
-);
+  )
+});

--- a/src/routes/api/data/queryAvailablePrograms/+server.ts
+++ b/src/routes/api/data/queryAvailablePrograms/+server.ts
@@ -1,0 +1,70 @@
+import { json } from '@sveltejs/kit';
+import { initLogger } from '$lib/common/config/loggerConfig';
+import { queryAvailableProgramsValidationSchema } from '$lib/server/schema/queryAvailableProgramsSchema';
+import { getProgramsFromCatalogMajor, getProgramsFromIds } from '$lib/server/db/program';
+import type { Program } from '@prisma/client';
+import type { RequestHandler } from '@sveltejs/kit';
+
+const logger = initLogger('APIRouteHandler (/api/data/queryAvailablePrograms)');
+
+export const GET: RequestHandler = async ({ locals, url }) => {
+  try {
+    // ensure request is authenticated
+    if (!locals.session) {
+      return json(
+        {
+          message: 'Available programs query request must be authenticated.'
+        },
+        {
+          status: 401
+        }
+      );
+    }
+
+    // validation
+    const data = Object.fromEntries(url.searchParams);
+    const parseResults = queryAvailableProgramsValidationSchema.safeParse(data);
+
+    if (parseResults.success) {
+      let results: Program[] = [];
+
+      if ('id' in parseResults.data) {
+        // TODO: enable ability to fetch multiple programs?
+        results = await getProgramsFromIds([parseResults.data.id]);
+      } else {
+        results = await getProgramsFromCatalogMajor(
+          parseResults.data.catalog,
+          parseResults.data.majorName
+        );
+      }
+
+      return json({
+        message: 'Available programs query successful.',
+        results
+      });
+    } else {
+      const { fieldErrors: validationErrors } = parseResults.error.flatten();
+
+      return json(
+        {
+          message: 'Invalid input received.',
+          validationErrors
+        },
+        {
+          status: 400
+        }
+      );
+    }
+  } catch (error) {
+    logger.error('an internal error occurred', error);
+    return json(
+      {
+        message:
+          'An error occurred while querying available programs, please try again a bit later.'
+      },
+      {
+        status: 500
+      }
+    );
+  }
+};

--- a/tests/api/getAvailableCatalogsTests.test.ts
+++ b/tests/api/getAvailableCatalogsTests.test.ts
@@ -5,7 +5,7 @@ import { createUser, deleteUser } from '$lib/server/db/user';
 const GET_AVAILABLE_CATALOGS_API_TESTS_EMAIL =
   'pfb_test_getAvailableCatalogsAPI_playwright@test.com';
 
-test.describe('getAvailableStartYears tests', () => {
+test.describe('getAvailableCatalogsTests tests', () => {
   test.beforeAll(async () => {
     // create account
     await createUser({

--- a/tests/api/queryAvailableProgramsTests.test.ts
+++ b/tests/api/queryAvailableProgramsTests.test.ts
@@ -1,0 +1,240 @@
+import { expect, test } from '@playwright/test';
+import { performLoginBackend } from 'tests/util/userTestUtil';
+import { createUser, deleteUser } from '$lib/server/db/user';
+
+const QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL =
+  'pfb_test_queryAvailableProgramsAPI_playwright@test.com';
+
+test.describe('queryAvailableProgramsTests tests', () => {
+  test.beforeAll(async () => {
+    // create account
+    await createUser({
+      email: QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL,
+      username: 'test',
+      password: 'test'
+    });
+  });
+
+  test.afterAll(async () => {
+    // delete account
+    await deleteUser(QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL);
+  });
+
+  test('program query with no parameters has correct response', async ({ request }) => {
+    await performLoginBackend(request, QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL, 'test');
+
+    const res = await request.get('/api/data/queryAvailablePrograms');
+
+    const expectedResponseBody = {
+      message: 'Invalid input received.',
+      validationErrors: {
+        query: ['Invalid query for available programs.']
+      }
+    };
+
+    expect(res.status()).toBe(400);
+    expect(await res.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('program query with invalid combination of parameters has correct response', async ({
+    request
+  }) => {
+    await performLoginBackend(request, QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL, 'test');
+
+    // id+major
+    const res1 = await request.get(
+      '/api/data/queryAvailablePrograms?id=c888a952-751b-4879-afa7-45dd17ba5804&majorName=test'
+    );
+
+    // id+major+catalog
+    const res2 = await request.get(
+      '/api/data/queryAvailablePrograms?id=c888a952-751b-4879-afa7-45dd17ba5804&majorName=test&catalog=2015-2017'
+    );
+
+    // id+catalog
+    const res3 = await request.get(
+      '/api/data/queryAvailablePrograms?id=c888a952-751b-4879-afa7-45dd17ba5804&catalog=2015-2017'
+    );
+
+    const expectedResponseBody = {
+      message: 'Invalid input received.',
+      validationErrors: {
+        query: ['Invalid query for available programs.']
+      }
+    };
+
+    expect(res1.status()).toBe(400);
+    expect(res2.status()).toBe(400);
+    expect(res3.status()).toBe(400);
+    expect(await res1.json()).toStrictEqual(expectedResponseBody);
+    expect(await res2.json()).toStrictEqual(expectedResponseBody);
+    expect(await res3.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('program query with invalid id format handled correctly', async ({ request }) => {
+    await performLoginBackend(request, QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL, 'test');
+
+    const res = await request.get('/api/data/queryAvailablePrograms?id=thisisnotauuid');
+
+    const expectedResponseBody = {
+      message: 'Invalid input received.',
+      validationErrors: {
+        query: ['Invalid format for program unique ID.']
+      }
+    };
+
+    expect(res.status()).toBe(400);
+    expect(await res.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('program query with invalid majorName format handled correctly', async ({ request }) => {
+    await performLoginBackend(request, QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL, 'test');
+
+    const res = await request.get('/api/data/queryAvailablePrograms?catalog=2015-2017&majorName=');
+
+    const expectedResponseBody = {
+      message: 'Invalid input received.',
+      validationErrors: {
+        query: ['Major name must not be empty.']
+      }
+    };
+
+    expect(res.status()).toBe(400);
+    expect(await res.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('program query with invalid catalog format handled correctly', async ({ request }) => {
+    await performLoginBackend(request, QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL, 'test');
+
+    const res1 = await request.get('/api/data/queryAvailablePrograms?majorName=test&catalog=test');
+    const res2 = await request.get('/api/data/queryAvailablePrograms?majorName=test&catalog=15-17');
+    const res3 = await request.get(
+      '/api/data/queryAvailablePrograms?majorName=test&catalog=2015-test'
+    );
+    const res4 = await request.get(
+      '/api/data/queryAvailablePrograms?majorName=test&catalog=2017-2015'
+    );
+
+    const expectedResponseBody = {
+      message: 'Invalid input received.',
+      validationErrors: {
+        query: ['Invalid catalog format.']
+      }
+    };
+
+    expect(res1.status()).toBe(400);
+    expect(res2.status()).toBe(400);
+    expect(res3.status()).toBe(400);
+    expect(res4.status()).toBe(400);
+    expect(await res1.json()).toStrictEqual(expectedResponseBody);
+    expect(await res2.json()).toStrictEqual(expectedResponseBody);
+    expect(await res3.json()).toStrictEqual(expectedResponseBody);
+    expect(await res4.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('successful program query with id, id exists', async ({ request }) => {
+    await performLoginBackend(request, QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL, 'test');
+
+    const res = await request.get(
+      '/api/data/queryAvailablePrograms?id=0017f92d-d73f-4819-9d59-8c658cd29be5'
+    );
+
+    const expectedResponseBody = {
+      message: 'Available programs query successful.',
+      results: [
+        {
+          id: '0017f92d-d73f-4819-9d59-8c658cd29be5',
+          catalog: '2017-2019',
+          majorName: 'General Engineering',
+          concName: 'ICS: Product Design Emphasis*',
+          code: '17-19.52GENEBSU.EMPH-ProductDesign',
+          dataLink:
+            'http://flowcharts.calpoly.edu/downloads/mymap/17-19.52GENEBSU.EMPH-ProductDesign.pdf'
+        }
+      ]
+    };
+
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('successful program query with id, id does not exist', async ({ request }) => {
+    await performLoginBackend(request, QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL, 'test');
+
+    const res = await request.get(
+      '/api/data/queryAvailablePrograms?id=c888a952-751b-4879-afa7-45dd17ba5804'
+    );
+
+    const expectedResponseBody = {
+      message: 'Available programs query successful.',
+      results: []
+    };
+
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('successful program query with catalog+majorName, returns results', async ({ request }) => {
+    await performLoginBackend(request, QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL, 'test');
+
+    const res = await request.get(
+      '/api/data/queryAvailablePrograms?catalog=2015-2017&majorName=Computer Science'
+    );
+
+    const expectedResponseBody = {
+      message: 'Available programs query successful.',
+      results: [
+        {
+          catalog: '2015-2017',
+          code: '15-17.52CSCBSU.IENTCSCU',
+          concName: 'Interactive Entertainment',
+          dataLink: 'http://flowcharts.calpoly.edu/downloads/mymap/15-17.52CSCBSU.IENTCSCU.pdf',
+          id: '686a70e5-15b6-429e-8e7c-8d83ab5e5809',
+          majorName: 'Computer Science'
+        },
+        {
+          catalog: '2015-2017',
+          code: '15-17.52CSCBSU',
+          concName: 'Non-Concentration Option',
+          dataLink: 'http://flowcharts.calpoly.edu/downloads/mymap/15-17.52CSCBSU.pdf',
+          id: '3acb81e1-2b71-4aa7-bd89-b380fd356a70',
+          majorName: 'Computer Science'
+        }
+      ]
+    };
+
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('successful program query with catalog+majorName, does not return results', async ({
+    request
+  }) => {
+    await performLoginBackend(request, QUERY_AVAILABLE_PROGRAMS_API_TESTS_EMAIL, 'test');
+
+    const res = await request.get(
+      '/api/data/queryAvailablePrograms?catalog=2015-2017&majorName=nice'
+    );
+
+    const expectedResponseBody = {
+      message: 'Available programs query successful.',
+      results: []
+    };
+
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('401 case handled properly', async ({ request }) => {
+    const res = await request.get('/api/data/queryAvailablePrograms?id=test');
+    const resData = (await res.json()) as unknown;
+
+    expect(res.ok()).toBeFalsy();
+    expect(res.status()).toBe(401);
+    expect(resData).toStrictEqual({
+      message: 'Available programs query request must be authenticated.'
+    });
+  });
+
+  // TODO: add 500 case
+});


### PR DESCRIPTION
This PR is to create a new endpoint, `/api/data/queryAvailablePrograms`, that allows the user to query available programs in the following ways:

1. via a program ID (UUID)
2. via a catalog and major combination

This is part of task 3 of #2.

New tests were created for this API.