### PR TITLE
Remove `apiData` from the `generateFlowchart` API

### DIFF
--- a/src/lib/server/db/startYear.ts
+++ b/src/lib/server/db/startYear.ts
@@ -3,3 +3,14 @@ import { prisma } from '$lib/server/db/prisma';
 export async function getStartYears(): Promise<string[]> {
   return (await prisma.startYear.findMany()).map((startYear) => startYear.year);
 }
+
+export async function validateStartYear(startYear: string): Promise<boolean> {
+  const res = await prisma.startYear.findMany({
+    where: {
+      year: {
+        in: [startYear]
+      }
+    }
+  });
+  return !!res.length;
+}

--- a/src/lib/server/db/templateFlowchart.ts
+++ b/src/lib/server/db/templateFlowchart.ts
@@ -1,49 +1,16 @@
 import { prisma } from '$lib/server/db/prisma';
-import { Prisma } from '@prisma/client';
 import { initLogger } from '$lib/common/config/loggerConfig';
-import type { Program, TemplateFlowchart } from '@prisma/client';
+import type { TemplateFlowchart } from '@prisma/client';
 
 const logger = initLogger('DB/TemplateFlowchart');
 
-export async function getTemplateFlowcharts(programIds: string[]): Promise<
-  {
-    flowchart: TemplateFlowchart;
-    programMetadata: Program;
-  }[]
-> {
-  // use raw query here bc Prisma doesn't currently use joins
-  // and raw join here is much more efficient than the auto multi-query fetch
-  // for relations that Prisma uses, see here:
-  // https://github.com/prisma/prisma/discussions/8840
-  // https://github.com/prisma/prisma/issues/4997
-
-  const res = (
-    await prisma.$queryRaw<
-      (TemplateFlowchart & Program)[]
-    >`SELECT * FROM TemplateFlowchart INNER JOIN Program ON programId = id WHERE programId IN (${Prisma.join(
-      programIds
-    )})`
-  ).map((resEntry) => {
-    const flowchart: TemplateFlowchart = {
-      programId: resEntry.programId,
-      termData: resEntry.termData,
-      flowUnitTotal: resEntry.flowUnitTotal,
-      notes: resEntry.notes,
-      version: resEntry.version
-    };
-    const programMetadata: Program = {
-      id: resEntry.id,
-      catalog: resEntry.catalog,
-      majorName: resEntry.majorName,
-      concName: resEntry.concName,
-      code: resEntry.code,
-      dataLink: resEntry.dataLink
-    };
-
-    return {
-      flowchart,
-      programMetadata
-    };
+export async function getTemplateFlowcharts(programIds: string[]): Promise<TemplateFlowchart[]> {
+  const res = await prisma.templateFlowchart.findMany({
+    where: {
+      programId: {
+        in: programIds
+      }
+    }
   });
 
   logger.info(`Successfully got template flowchart(s) ${programIds.join(',')}`);

--- a/src/lib/server/schema/common.ts
+++ b/src/lib/server/schema/common.ts
@@ -1,10 +1,26 @@
 import { z } from 'zod';
 
+export const startYearSchema = z
+  .string({
+    required_error: 'Start year is required.'
+  })
+  .refine((startYear) => {
+    const num = Number(startYear);
+    return !isNaN(num) && startYear.length === 4 && num >= 2000;
+  }, 'Invalid start year format.');
+
 export const catalogSchema = z
   .string({
     required_error: 'Catalog is required.'
   })
   .refine((catalog) => {
     const parts = catalog.split('-').map((part) => Number(part));
-    return catalog.length === 9 && !isNaN(parts[0]) && !isNaN(parts[1]) && parts[1] > parts[0];
+    return (
+      catalog.length === 9 &&
+      !isNaN(parts[0]) &&
+      !isNaN(parts[1]) &&
+      parts[0] >= 2000 &&
+      parts[1] >= 2000 &&
+      parts[1] > parts[0]
+    );
   }, 'Invalid catalog format.');

--- a/src/lib/server/schema/generateFlowchartSchema.ts
+++ b/src/lib/server/schema/generateFlowchartSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { apiData } from '$lib/server/config/apiDataConfig';
+import { startYearSchema } from '$lib/server/schema/common';
 import { FLOW_NAME_MAX_LENGTH } from '$lib/common/config/flowDataConfig';
 
 // validation schema for generate flowchart payload
@@ -15,22 +15,13 @@ export const generateFlowchartSchema = z.object({
     .max(FLOW_NAME_MAX_LENGTH, {
       message: `Flowchart name too long, max length is ${FLOW_NAME_MAX_LENGTH} characters.`
     }),
-  startYear: z
-    .string({
-      required_error: 'Start year is required.'
-    })
-    .refine((startYear) => apiData.startYears.includes(startYear), 'Invalid start year.'),
+  startYear: startYearSchema,
   // encoded as comma-separated values in single string due to search param string requirements
   programIds: z
     .array(
-      z.string().refine(
-        (progId) => apiData.programData.find((prog) => prog.id === progId),
-        (progId) => {
-          return {
-            message: `Program ID ${progId} is invalid.`
-          };
-        }
-      ),
+      z.string().uuid({
+        message: 'Invalid format for program unique ID.'
+      }),
       {
         required_error: 'Program Id(s) required.'
       }

--- a/src/lib/server/schema/generateFlowchartSchema.ts
+++ b/src/lib/server/schema/generateFlowchartSchema.ts
@@ -20,7 +20,7 @@ export const generateFlowchartSchema = z.object({
   programIds: z
     .array(
       z.string().uuid({
-        message: 'Invalid format for program unique ID.'
+        message: 'Invalid format for program unique ID(s).'
       }),
       {
         required_error: 'Program Id(s) required.'

--- a/src/lib/server/util/courseCacheUtil.test.ts
+++ b/src/lib/server/util/courseCacheUtil.test.ts
@@ -1,10 +1,7 @@
 import * as apiDataConfig from '$lib/server/config/apiDataConfig';
-import {
-  generateCourseCacheFlowchart,
-  generateUserCourseCache
-} from '$lib/server/util/courseCacheUtil';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
 import { cloneAndDeleteNestedProperty } from '../../../../tests/util/testUtil';
+import { generateCourseCacheFlowcharts } from '$lib/server/util/courseCacheUtil';
 import type { Program } from '@prisma/client';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache } from '$lib/types';
@@ -27,7 +24,7 @@ function generateProgramCache(programIds: string[]): Program[] {
   return programCache;
 }
 
-describe('generateCourseCacheFlowchart tests', () => {
+describe('generateCourseCacheFlowcharts single flowchart tests', () => {
   test('generate course cache for flowchart with empty data', async () => {
     const flow1: Flowchart = {
       hash: '',
@@ -52,7 +49,7 @@ describe('generateCourseCacheFlowchart tests', () => {
       courses: []
     }));
 
-    expect(await generateCourseCacheFlowchart(flow1, [])).toStrictEqual(expectedCourseCache);
+    expect(await generateCourseCacheFlowcharts([flow1], [])).toStrictEqual(expectedCourseCache);
   });
 
   test('generate course cache for one flowchart with one catalog', async () => {
@@ -137,7 +134,7 @@ describe('generateCourseCacheFlowchart tests', () => {
 
     expect(
       cloneAndDeleteNestedProperty(
-        await generateCourseCacheFlowchart(flow1, programCache),
+        await generateCourseCacheFlowcharts([flow1], programCache),
         'dynamicTerms'
       )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
@@ -264,7 +261,7 @@ describe('generateCourseCacheFlowchart tests', () => {
 
     expect(
       cloneAndDeleteNestedProperty(
-        await generateCourseCacheFlowchart(flow1, programCache),
+        await generateCourseCacheFlowcharts([flow1], programCache),
         'dynamicTerms'
       )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
@@ -349,21 +346,21 @@ describe('generateCourseCacheFlowchart tests', () => {
 
     expect(
       cloneAndDeleteNestedProperty(
-        await generateCourseCacheFlowchart(flow1, apiDataConfig.apiData.programData),
+        await generateCourseCacheFlowcharts([flow1], apiDataConfig.apiData.programData),
         'dynamicTerms'
       )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
   });
 });
 
-describe('generateUserCourseCache tests', () => {
-  test('generate user course cache for user with no flowcharts', async () => {
+describe('generateCourseCacheFlowcharts multi-flowchart tests', () => {
+  test('generate flowcharts course cache for no flowcharts', async () => {
     const expectedCourseCache: CourseCache[] = [];
 
-    expect(await generateUserCourseCache([], [])).toStrictEqual(expectedCourseCache);
+    expect(await generateCourseCacheFlowcharts([], [])).toStrictEqual(expectedCourseCache);
   });
 
-  test('generate user course cache for user with one flowchart with empty course data', async () => {
+  test('generate flowcharts course cache for user with one flowchart with empty course data', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -382,10 +379,10 @@ describe('generateUserCourseCache tests', () => {
 
     const expectedCourseCache: CourseCache[] = [];
 
-    expect(await generateUserCourseCache([flow1], [])).toStrictEqual(expectedCourseCache);
+    expect(await generateCourseCacheFlowcharts([flow1], [])).toStrictEqual(expectedCourseCache);
   });
 
-  test('generate user course cache for user with one flowchart with one catalog', async () => {
+  test('generate flowcharts course cache for user with one flowchart with one catalog', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -466,13 +463,13 @@ describe('generateUserCourseCache tests', () => {
 
     expect(
       cloneAndDeleteNestedProperty(
-        await generateUserCourseCache([flow1], programCache),
+        await generateCourseCacheFlowcharts([flow1], programCache),
         'dynamicTerms'
       )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
   });
 
-  test('generate user course cache for one flowchart with two catalogs', async () => {
+  test('generate flowcharts course cache for one flowchart with two catalogs', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -592,13 +589,13 @@ describe('generateUserCourseCache tests', () => {
 
     expect(
       cloneAndDeleteNestedProperty(
-        await generateUserCourseCache([flow1], programCache),
+        await generateCourseCacheFlowcharts([flow1], programCache),
         'dynamicTerms'
       )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
   });
 
-  test('generate user course cache for user with two flowcharts', async () => {
+  test('generate flowcharts course cache for user with two flowcharts', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -756,13 +753,13 @@ describe('generateUserCourseCache tests', () => {
 
     expect(
       cloneAndDeleteNestedProperty(
-        await generateUserCourseCache([flow1, flow2], programCache),
+        await generateCourseCacheFlowcharts([flow1, flow2], programCache),
         'dynamicTerms'
       )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
   });
 
-  test('generated user course cache only includes catalogs with courses in them', async () => {
+  test('generated flowcharts course cache only includes catalogs with courses in them', async () => {
     const flow1: Flowchart = {
       hash: '',
       id: '',
@@ -841,7 +838,168 @@ describe('generateUserCourseCache tests', () => {
 
     expect(
       cloneAndDeleteNestedProperty(
-        await generateUserCourseCache([flow1], apiDataConfig.apiData.programData),
+        await generateCourseCacheFlowcharts([flow1], apiDataConfig.apiData.programData),
+        'dynamicTerms'
+      )
+    ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));
+  });
+
+  test('generate flowcharts course cache and enforce unique courses across caches', async () => {
+    const flow1: Flowchart = {
+      hash: '',
+      id: '',
+      lastUpdatedUTC: new Date(),
+      name: '',
+      notes: '',
+      ownerId: '',
+      programId: ['68be11b7-389b-4ebc-9b95-8997e7314497'],
+      startYear: '',
+      termData: [
+        {
+          tIndex: 1,
+          tUnits: '12',
+          courses: [
+            {
+              color: '#FEFD9A',
+              id: 'AGC301'
+            },
+            {
+              color: '#FEFD9A',
+              id: 'AGB301'
+            },
+            {
+              color: '#FEFD9A',
+              id: 'JOUR312'
+            }
+          ]
+        }
+      ],
+      unitTotal: '',
+      version: CURRENT_FLOW_DATA_VERSION,
+      importedId: null,
+      publishedId: null
+    };
+
+    const flow2: Flowchart = {
+      hash: '',
+      id: '',
+      lastUpdatedUTC: new Date(),
+      name: '',
+      notes: '',
+      ownerId: '',
+      programId: ['cb65784d-23d6-44a9-ae7a-03b4b50d5b36'],
+      startYear: '',
+      termData: [
+        {
+          tIndex: 1,
+          tUnits: '17-19',
+          courses: [
+            {
+              color: '#FEFD9A',
+              id: 'AGC301'
+            },
+            {
+              color: '#FEFD9A',
+              id: 'AGB301'
+            },
+            {
+              color: '#FEFD9A',
+              id: 'JOUR312'
+            },
+            {
+              color: '#FEFD9A',
+              id: 'KINE134'
+            },
+            {
+              color: '#DCFDD2',
+              customDesc:
+                'One course from each of the following GE areas must be completed: A1, A2, A3, C1, C2, Lower-Division C, Upper-Division C, D1, E, F, and GE Elective. Upper-Division C should be taken only after Junior standing is reached (90 units). Refer to online catalog for GE course selection, United States Cultural Pluralism (USCP), and Graduation Writing Requirement (GWR) requirements.',
+              customUnits: '4-6',
+              id: null,
+              customId: 'GE'
+            },
+            {
+              color: '#DA9593',
+              customDesc:
+                'Students can attempt to fulfill the requirement after 90 earned units; students should complete the requirement before senior year. Refer to current catalog for prerequisites. Any GWR class or GWR exam can go here.',
+              id: null,
+              customId: 'Graduation Writing Requirement'
+            }
+          ]
+        }
+      ],
+      unitTotal: '',
+      version: CURRENT_FLOW_DATA_VERSION,
+      importedId: null,
+      publishedId: null
+    };
+
+    // dedup programIds - need to do here but won't happen in prod
+    const programCache = generateProgramCache([
+      ...new Set([...flow1.programId, ...flow2.programId])
+    ]);
+
+    const courseCache1517 = {
+      catalog: '2015-2017',
+      courses: [
+        {
+          id: 'AGB301',
+          catalog: '2015-2017',
+          displayName: 'Food and Fiber Marketing',
+          units: '4',
+          desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
+          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        },
+        {
+          id: 'AGC301',
+          catalog: '2015-2017',
+          displayName: 'New Media Communication Strategies in Agriculture',
+          units: '4',
+          desc: 'Exploration and implementation of emerging new media communication strategies and technologies to convey information on important issues in agriculture to a global audience.  Focus on food and farming dialogues currently populating conversations about production agriculture.  Adaptation of different writing styles based on requirements of the various new media channels.  Analysis of metrics to measure level of engagement with desired audience.  3 lectures, 1 laboratory.\n',
+          addl: 'Term Typically Offered: W\nPrerequisite: JOUR 205. Recommended: JOUR 203.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        },
+        {
+          id: 'JOUR312',
+          catalog: '2015-2017',
+          displayName: 'Public Relations',
+          units: '4',
+          desc: 'Overview of the history, growth and ongoing development of public relations as an information management function in a multicultural environment.  Public relations practices used in commercial and non-profit sectors, and firsthand application of public relations skills.  4 lectures.\n',
+          addl: 'Term Typically Offered: F, W\nPrerequisite: Sophomore standing.\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        }
+      ]
+    };
+
+    const courseCache2226 = {
+      catalog: '2022-2026',
+      courses: [
+        {
+          id: 'KINE134',
+          catalog: '2022-2026',
+          displayName: 'Pickleball',
+          units: '1',
+          desc: 'Basic instruction in skill development, knowledge, and desirable attitudes toward physical activity. Fundamental pickleball skills, knowledge, and strategy such that beginning to intermediate levels of play are attained. Enrollment is open to all students. Total limited to 12 units of credit earned in basic instructional KINE courses (KINE 100-176) for non-majors. The following restrictions apply to KINE 100-176: 1) no more than two different activity courses or more than one section of an individual activity course may be taken for credit in any one quarter, 2) a student may not enroll simultaneously in the same quarter for a beginning, intermediate and/or advanced activity course, and 3) any level of an activity course can be repeated only once for credit. Total credit limited to 2 units. Credit/No Credit grading only. 1 activity.\n',
+          addl: 'Term Typically Offered: F, SP\nCR/NC\n',
+          gwrCourse: false,
+          uscpCourse: false,
+          dynamicTerms: null
+        }
+      ]
+    };
+
+    const expectedCourseCache = [courseCache1517, courseCache2226];
+
+    expect(
+      cloneAndDeleteNestedProperty(
+        await generateCourseCacheFlowcharts([flow1, flow2], programCache, true),
         'dynamicTerms'
       )
     ).toStrictEqual(cloneAndDeleteNestedProperty(expectedCourseCache, 'dynamicTerms'));

--- a/src/lib/server/util/courseCacheUtil.ts
+++ b/src/lib/server/util/courseCacheUtil.ts
@@ -1,11 +1,16 @@
 import { getCourseData } from '$lib/server/db/course';
 import { getCatalogFromProgramIDIndex } from '$lib/common/util/courseDataUtilCommon';
+import type { Term } from '$lib/common/schema/flowchartSchema';
 import type { Program } from '@prisma/client';
-import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache } from '$lib/types';
 
 export async function generateCourseCacheFlowcharts(
-  flowcharts: Flowchart[],
+  // smaller type than full Flowchart so we can pass TemplateFlowchart
+  // information into here as well
+  flowcharts: {
+    programId: string[];
+    termData: Term[];
+  }[],
   programCache: Program[]
 ): Promise<CourseCache[]> {
   const catalogs = [...new Set(programCache.map((prog) => prog.catalog))];

--- a/src/lib/server/util/flowDataUtil.ts
+++ b/src/lib/server/util/flowDataUtil.ts
@@ -62,15 +62,12 @@ export function convertFlowchartToDBFlowchart(flowchartData: MutateFlowchartData
   return convertedFlowchart;
 }
 
-export async function generateFlowchart(data: GenerateFlowchartData): Promise<{
-  flowchart: Flowchart;
-  programMetadata: Program[];
-}> {
+export async function generateFlowchart(data: GenerateFlowchartData): Promise<Flowchart> {
   const templateFlowcharts = await getTemplateFlowcharts(data.programIds);
 
   // presumably templateFlowchart termData has been validated before being accessed here so explicitly cast
   const mergedFlowchartTermData = mergeFlowchartsCourseData(
-    templateFlowcharts.map((templateFlowchart) => templateFlowchart.flowchart.termData as Term[]),
+    templateFlowcharts.map((templateFlowchart) => templateFlowchart.termData as Term[]),
     data.programIds,
     apiData.courseData,
     apiData.programData
@@ -122,10 +119,5 @@ export async function generateFlowchart(data: GenerateFlowchartData): Promise<{
   // compute hash
   generatedFlowchart.hash = generateFlowHash(generatedFlowchart);
 
-  // safe to map programMetadata here (re: dedup) as request is validated to have
-  // unique programIds before generating
-  return {
-    flowchart: generatedFlowchart,
-    programMetadata: templateFlowcharts.map((data) => data.programMetadata)
-  };
+  return generatedFlowchart;
 }

--- a/src/lib/server/util/flowDataUtil.ts
+++ b/src/lib/server/util/flowDataUtil.ts
@@ -63,11 +63,19 @@ export function convertFlowchartToDBFlowchart(flowchartData: MutateFlowchartData
 }
 
 export async function generateFlowchart(data: GenerateFlowchartData): Promise<Flowchart> {
-  const templateFlowcharts = await getTemplateFlowcharts(data.programIds);
+  // fetch required data
+  // presumably templateFlowchart termData has been validated before being persisted to DB
+  // and accessed here so safe to explicitly cast
+  const templateFlowcharts = (await getTemplateFlowcharts(data.programIds)).map((flowchart) => {
+    return {
+      ...flowchart,
+      programId: [flowchart.programId],
+      termData: flowchart.termData as Term[]
+    };
+  });
 
-  // presumably templateFlowchart termData has been validated before being accessed here so explicitly cast
   const mergedFlowchartTermData = mergeFlowchartsCourseData(
-    templateFlowcharts.map((templateFlowchart) => templateFlowchart.termData as Term[]),
+    templateFlowcharts.map((templateFlowchart) => templateFlowchart.termData),
     data.programIds,
     apiData.courseData,
     apiData.programData

--- a/src/routes/api/data/generateFlowchart/+server.ts
+++ b/src/routes/api/data/generateFlowchart/+server.ts
@@ -4,7 +4,6 @@ import { generateFlowchart } from '$lib/server/util/flowDataUtil';
 import { validateStartYear } from '$lib/server/db/startYear';
 import { getProgramsFromIds } from '$lib/server/db/program';
 import { generateFlowchartSchema } from '$lib/server/schema/generateFlowchartSchema';
-import { generateCourseCacheFlowcharts } from '$lib/server/util/courseCacheUtil';
 import type { RequestHandler } from '@sveltejs/kit';
 
 const logger = initLogger('APIRouteHandler (/api/data/generateFlowchart)');
@@ -68,13 +67,16 @@ export const GET: RequestHandler = async ({ locals, url }) => {
         );
       }
 
-      const generatedFlowchart = await generateFlowchart(parseResults.data, programMetadata);
+      const { flowchart: generatedFlowchart, courseCache } = await generateFlowchart(
+        parseResults.data,
+        programMetadata
+      );
 
       return json({
         message: 'Flowchart successfully generated.',
         generatedFlowchart,
         ...(parseResults.data.generateCourseCache && {
-          courseCache: await generateCourseCacheFlowcharts([generatedFlowchart], programMetadata)
+          courseCache
         })
       });
     } else {

--- a/src/routes/api/data/generateFlowchart/+server.ts
+++ b/src/routes/api/data/generateFlowchart/+server.ts
@@ -68,7 +68,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
         );
       }
 
-      const { flowchart: generatedFlowchart, rest } = await generateFlowchart(parseResults.data);
+      const generatedFlowchart = await generateFlowchart(parseResults.data);
 
       return json({
         message: 'Flowchart successfully generated.',

--- a/src/routes/api/data/generateFlowchart/+server.ts
+++ b/src/routes/api/data/generateFlowchart/+server.ts
@@ -43,7 +43,10 @@ export const GET: RequestHandler = async ({ locals, url }) => {
       if (!startYearValid) {
         return json(
           {
-            message: 'Invalid start year.'
+            message: 'Invalid input received.',
+            validationErrors: {
+              startYear: [`Invalid start year ${parseResults.data.startYear}.`]
+            }
           },
           {
             status: 400
@@ -52,14 +55,16 @@ export const GET: RequestHandler = async ({ locals, url }) => {
       }
 
       // validate programIds
-      const programIdsSet = new Set(parseResults.data.programIds);
-      const invalidProgramIds = programMetadata
-        .map((prog) => prog.id)
-        .filter((id) => !programIdsSet.has(id));
+      const programIdsSet = new Set(programMetadata.map((prog) => prog.id));
+      const invalidProgramIds = parseResults.data.programIds.filter((id) => !programIdsSet.has(id));
+
       if (invalidProgramIds.length) {
         return json(
           {
-            message: `Invalid program IDs ${invalidProgramIds.toString()}.`
+            message: 'Invalid input received.',
+            validationErrors: {
+              programIds: [`Invalid program id(s) ${invalidProgramIds.toString()}.`]
+            }
           },
           {
             status: 400

--- a/src/routes/api/data/generateFlowchart/+server.ts
+++ b/src/routes/api/data/generateFlowchart/+server.ts
@@ -4,7 +4,7 @@ import { generateFlowchart } from '$lib/server/util/flowDataUtil';
 import { validateStartYear } from '$lib/server/db/startYear';
 import { getProgramsFromIds } from '$lib/server/db/program';
 import { generateFlowchartSchema } from '$lib/server/schema/generateFlowchartSchema';
-import { generateCourseCacheFlowchart } from '$lib/server/util/courseCacheUtil';
+import { generateCourseCacheFlowcharts } from '$lib/server/util/courseCacheUtil';
 import type { RequestHandler } from '@sveltejs/kit';
 
 const logger = initLogger('APIRouteHandler (/api/data/generateFlowchart)');
@@ -74,7 +74,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
         message: 'Flowchart successfully generated.',
         generatedFlowchart,
         ...(parseResults.data.generateCourseCache && {
-          courseCache: await generateCourseCacheFlowchart(generatedFlowchart, programMetadata)
+          courseCache: await generateCourseCacheFlowcharts([generatedFlowchart], programMetadata)
         })
       });
     } else {

--- a/src/routes/api/data/generateFlowchart/+server.ts
+++ b/src/routes/api/data/generateFlowchart/+server.ts
@@ -68,7 +68,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
         );
       }
 
-      const generatedFlowchart = await generateFlowchart(parseResults.data);
+      const generatedFlowchart = await generateFlowchart(parseResults.data, programMetadata);
 
       return json({
         message: 'Flowchart successfully generated.',

--- a/src/routes/api/user/data/getUserFlowcharts/+server.ts
+++ b/src/routes/api/user/data/getUserFlowcharts/+server.ts
@@ -1,8 +1,8 @@
 import { json } from '@sveltejs/kit';
 import { initLogger } from '$lib/common/config/loggerConfig';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
-import { generateUserCourseCache } from '$lib/server/util/courseCacheUtil';
 import { getUserFlowchartsSchema } from '$lib/server/schema/getUserFlowchartsSchema';
+import { generateCourseCacheFlowcharts } from '$lib/server/util/courseCacheUtil';
 import type { Program } from '@prisma/client';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { RequestHandler } from '@sveltejs/kit';
@@ -50,7 +50,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
         message: 'User flowchart retrieval successful.',
         flowcharts,
         ...(parseResults.data.includeCourseCache && {
-          courseCache: await generateUserCourseCache(flowcharts, programMetadata)
+          courseCache: await generateCourseCacheFlowcharts(flowcharts, programMetadata)
         }),
         ...(parseResults.data.includeProgramMetadata && {
           programMetadata

--- a/tests/api/generateFlowchartApiTests.test.ts
+++ b/tests/api/generateFlowchartApiTests.test.ts
@@ -2729,7 +2729,7 @@ test.describe('generate flowchart api input tests', () => {
     const expectedResponseBody = {
       message: 'Invalid input received.',
       validationErrors: {
-        startYear: ['Invalid start year.']
+        startYear: ['Invalid start year format.']
       }
     };
 
@@ -2753,7 +2753,7 @@ test.describe('generate flowchart api input tests', () => {
     const expectedResponseBody = {
       message: 'Invalid input received.',
       validationErrors: {
-        programIds: ['Program ID invalid is invalid.']
+        programIds: ['Invalid format for program unique ID(s).']
       }
     };
 
@@ -2777,7 +2777,7 @@ test.describe('generate flowchart api input tests', () => {
     const expectedResponseBody = {
       message: 'Invalid input received.',
       validationErrors: {
-        programIds: ['Program ID invalid is invalid.']
+        programIds: ['Invalid format for program unique ID(s).']
       }
     };
 
@@ -2799,7 +2799,7 @@ test.describe('generate flowchart api input tests', () => {
     const expectedResponseBody = {
       message: 'Invalid input received.',
       validationErrors: {
-        programIds: ['Program ID  is invalid.']
+        programIds: ['Invalid format for program unique ID(s).']
       }
     };
 

--- a/tests/api/generateFlowchartApiTests.test.ts
+++ b/tests/api/generateFlowchartApiTests.test.ts
@@ -2715,7 +2715,7 @@ test.describe('generate flowchart api input tests', () => {
     expect(await res.json()).toStrictEqual(expectedResponseBody);
   });
 
-  test('generate flowchart api returns 400 w invalid start year', async ({ request }) => {
+  test('generate flowchart api returns 400 w invalid start year format', async ({ request }) => {
     await performLoginBackend(request, GENERATE_FLOWCHART_TESTS_API_1_EMAIL, 'test');
 
     const searchParams = new URLSearchParams({
@@ -2730,6 +2730,28 @@ test.describe('generate flowchart api input tests', () => {
       message: 'Invalid input received.',
       validationErrors: {
         startYear: ['Invalid start year format.']
+      }
+    };
+
+    expect(res.status()).toBe(400);
+    expect(await res.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('generate flowchart api returns 400 w invalid start year', async ({ request }) => {
+    await performLoginBackend(request, GENERATE_FLOWCHART_TESTS_API_1_EMAIL, 'test');
+
+    const searchParams = new URLSearchParams({
+      name: 'test',
+      startYear: '2005',
+      programIds: '68be11b7-389b-4ebc-9b95-8997e7314497'
+    });
+
+    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+
+    const expectedResponseBody = {
+      message: 'Invalid input received.',
+      validationErrors: {
+        startYear: ['Invalid start year 2005.']
       }
     };
 
@@ -2822,6 +2844,52 @@ test.describe('generate flowchart api input tests', () => {
       message: 'Invalid input received.',
       validationErrors: {
         programIds: ['Cannot have duplicate program ids in flowchart.']
+      }
+    };
+
+    expect(res.status()).toBe(400);
+    expect(await res.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('generate flowchart api returns 400 w nonexistent program id (one)', async ({ request }) => {
+    await performLoginBackend(request, GENERATE_FLOWCHART_TESTS_API_1_EMAIL, 'test');
+
+    const searchParams = new URLSearchParams({
+      name: 'test',
+      startYear: '2020',
+      programIds: '1e292a2d-bdad-43b3-a89e-5ff8fc9b93d3'
+    });
+
+    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+
+    const expectedResponseBody = {
+      message: 'Invalid input received.',
+      validationErrors: {
+        programIds: ['Invalid program id(s) 1e292a2d-bdad-43b3-a89e-5ff8fc9b93d3.']
+      }
+    };
+
+    expect(res.status()).toBe(400);
+    expect(await res.json()).toStrictEqual(expectedResponseBody);
+  });
+
+  test('generate flowchart api returns 400 w nonexistent program id (two)', async ({ request }) => {
+    await performLoginBackend(request, GENERATE_FLOWCHART_TESTS_API_1_EMAIL, 'test');
+
+    const searchParams = new URLSearchParams({
+      name: 'test',
+      startYear: '2020',
+      programIds: '1e292a2d-bdad-43b3-a89e-5ff8fc9b93d3,0c1ea546-75ac-4753-9505-bcac01ef8505'
+    });
+
+    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+
+    const expectedResponseBody = {
+      message: 'Invalid input received.',
+      validationErrors: {
+        programIds: [
+          'Invalid program id(s) 1e292a2d-bdad-43b3-a89e-5ff8fc9b93d3,0c1ea546-75ac-4753-9505-bcac01ef8505.'
+        ]
       }
     };
 


### PR DESCRIPTION
This PR fully removes reliance on the `apiData` object in the `generateFlowchart API`. This work should have been included in a previous PR (#5) but there were a couple of things I forgot. The following things were changed:

1. change `startYear` and `programId[]` validation to use DB calls (one for each) instead of doing a `.includes` check for each submitted entry in the `apiData` object. If these validations fail, errors are returned to the user from the API in the usual manner.
2. updated `generateCourseCacheFlowchart()` to `generateCourseCacheFlowcharts()`, removing the now-redundant `generateUserCourseCache`. This was necessary to fetch the full course cache of a flowchart/template flowchart(s) (that potentially have multiple programs) before they were merged in the `generateFlowchart()` step. This also closes issue #4.

Fixed and added tests to accommodate these changes.