### PR TITLE
Remove user data mutation reliance on `apiData`

### DIFF
--- a/src/lib/server/util/courseCacheUtil.ts
+++ b/src/lib/server/util/courseCacheUtil.ts
@@ -84,6 +84,9 @@ export async function generateCourseCacheFlowcharts(
   return flowchartCourseCache.filter((cache) => cache.courses.length);
 }
 
+// TODO: add tests? - the functionality here is already covered
+// by e2e tests (eg flowTermModApiTests) so not sure if explicit
+// unit tests are required
 export async function generateCourseCacheFromUpdateChunks(
   flowcharts: Flowchart[],
   chunksList: UserDataUpdateChunk[],

--- a/src/lib/server/util/courseCacheUtil.ts
+++ b/src/lib/server/util/courseCacheUtil.ts
@@ -1,8 +1,13 @@
+import { initLogger } from '$lib/common/config/loggerConfig';
 import { getCourseData } from '$lib/server/db/course';
 import { getCatalogFromProgramIDIndex } from '$lib/common/util/courseDataUtilCommon';
-import type { Term } from '$lib/common/schema/flowchartSchema';
+import { UserDataUpdateChunkType, UserDataUpdateChunkTERM_MODCourseDataFrom } from '$lib/types';
 import type { Program } from '@prisma/client';
 import type { CourseCache } from '$lib/types';
+import type { UserDataUpdateChunk } from '$lib/common/schema/mutateUserDataSchema';
+import type { Course, Flowchart, Term } from '$lib/common/schema/flowchartSchema';
+
+const logger = initLogger('Util/CourseCacheUtil');
 
 export async function generateCourseCacheFlowcharts(
   // smaller type than full Flowchart so we can pass TemplateFlowchart
@@ -70,6 +75,106 @@ export async function generateCourseCacheFlowcharts(
     const idx = catalogs.findIndex((catalog) => catalog === crs.catalog);
     if (idx === -1) {
       throw new Error('courseCacheUtil: undefined catalog in courseCache Set');
+    }
+
+    flowchartCourseCache[idx].courses.push(crs);
+  });
+
+  // only return caches that have courses in them
+  return flowchartCourseCache.filter((cache) => cache.courses.length);
+}
+
+export async function generateCourseCacheFromUpdateChunks(
+  flowcharts: Flowchart[],
+  chunksList: UserDataUpdateChunk[],
+  programCache: Program[]
+): Promise<CourseCache[] | undefined> {
+  const catalogs = [...new Set(programCache.map((prog) => prog.catalog))];
+  const flowchartCourseCache: CourseCache[] = catalogs.map((catalog) => {
+    return {
+      catalog,
+      courses: []
+    };
+  });
+
+  // only keep the IDs in here vs. the entire course object so === equality works properly
+  const courseCatalogAndIds = new Set<string>();
+
+  // TERM_MOD is the only update chunk that currently needs course data
+  // so fetch course info for all non-custom courses in all TERM_MOD update chunks
+  for (let chunkIdx = 0; chunkIdx < chunksList.length; chunkIdx += 1) {
+    const chunk = chunksList[chunkIdx];
+    if (chunk.type === UserDataUpdateChunkType.FLOW_TERM_MOD) {
+      const flowchart = flowcharts.find((flowchart) => flowchart.id === chunk.data.id);
+
+      // can happen if bad data is passed in
+      if (!flowchart) {
+        logger.warn(
+          `generateCourseCacheFromUpdateChunks: unable to find flowchart with id ${chunk.data.id}`
+        );
+        return undefined;
+      }
+
+      for (let courseDiffIdx = 0; courseDiffIdx < chunk.data.termData.length; courseDiffIdx += 1) {
+        const courseDiff = chunk.data.termData[courseDiffIdx];
+
+        // get course information
+        let course: Course | undefined = undefined;
+        if (courseDiff.from === UserDataUpdateChunkTERM_MODCourseDataFrom.EXISTING) {
+          const term = flowchart.termData.find((term) => term.tIndex === courseDiff.data.tIndex);
+          course = term?.courses[courseDiff.data.cIndex];
+        } else {
+          course = courseDiff.data;
+        }
+
+        // can happen if bad data is passed in
+        if (!course) {
+          logger.warn(
+            `generateCourseCacheFromUpdateChunks: unable to find course in update chunk ${chunkIdx} courseDiff ${courseDiffIdx}`
+          );
+          return undefined;
+        }
+
+        // add course to cache only if noncustom
+        if (course.id) {
+          const courseCatalog = getCatalogFromProgramIDIndex(
+            course.programIdIndex ?? 0,
+            flowchart.programId,
+            programCache
+          );
+
+          // can happen if bad data is passed in
+          if (!courseCatalog) {
+            logger.warn(
+              `generateCourseCacheFromUpdateChunks: program with index ${
+                course.programIdIndex
+              } does not exist in programIds list ${flowchart.programId.join(',')}`
+            );
+            return undefined;
+          }
+
+          courseCatalogAndIds.add(`${courseCatalog},${course.id}`);
+        }
+      }
+    }
+  }
+
+  // get the courses
+  const courses = await getCourseData(
+    [...courseCatalogAndIds].map((courseId) => {
+      const parts = courseId.split(',');
+      return {
+        catalog: parts[0],
+        id: parts[1]
+      };
+    })
+  );
+
+  // map courses to course cache
+  courses.forEach((crs) => {
+    const idx = catalogs.findIndex((catalog) => catalog === crs.catalog);
+    if (idx === -1) {
+      throw new Error('generateCourseCacheFromUpdateChunks: undefined catalog in courseCache Set');
     }
 
     flowchartCourseCache[idx].courses.push(crs);

--- a/src/lib/server/util/mutateUserDataUtilServer.ts
+++ b/src/lib/server/util/mutateUserDataUtilServer.ts
@@ -77,11 +77,9 @@ export async function persistUserDataChangesServer(
     }
   });
 
-  // make sure we were able to get all flowcharts
-  if (flowchartMutationData.length !== flowchartModifyIds.length) {
-    logger.warn('Failed to find all requested flowcharts for mutateUserFlowcharts operation');
-    return false;
-  }
+  // dont need to validate whether we fetched all flowcharts
+  // bc this is done later in generateCourseCacheFromUpdateChunks()
+  // and mutateUserFlowcharts() as appropriate
 
   // get course caches for modify
   const courseCache = await generateCourseCacheFromUpdateChunks(

--- a/tests/api/updateUserFlowchartsApiTests/flowTermModApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowTermModApiTests.test.ts
@@ -414,6 +414,60 @@ test.describe('FLOW_TERM_MOD payload tests for updateUserFlowcharts API', () => 
     expect(res.status()).toBe(400);
     expect(await res.json()).toStrictEqual(expectedResponseBody);
   });
+
+  test('improperly formatted flow term mod chunk returns 400 (#9)', async ({ request }) => {
+    // create a flow to test with
+    await prisma.dBFlowchart.deleteMany({
+      where: {
+        ownerId: userId
+      }
+    });
+    const flowId = (
+      await populateFlowcharts(prisma, userId, 1, [
+        {
+          idx: 0,
+          info: {
+            termCount: 4,
+            longTermCount: 2
+          }
+        }
+      ])
+    )[0];
+
+    await performLoginBackend(request, FLOW_TERM_MOD_TESTS_API_EMAIL, 'test');
+
+    // existing indexes are invalid
+    const res = await request.post('/api/user/data/updateUserFlowcharts', {
+      data: {
+        updateChunks: [
+          {
+            type: UserDataUpdateChunkType.FLOW_TERM_MOD,
+            data: {
+              id: flowId,
+              tIndex: 0,
+              termData: [
+                {
+                  from: UserDataUpdateChunkTERM_MODCourseDataFrom.EXISTING,
+                  data: {
+                    tIndex: 50,
+                    cIndex: 25
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    });
+
+    const expectedResponseBody = {
+      message: 'Requested user flowchart updates are not valid for these data.'
+    };
+
+    expect(res.status()).toBe(400);
+    expect(await res.json()).toStrictEqual(expectedResponseBody);
+  });
+
   test('valid term mod chunk returns 200 (rearrange in single term)', async ({ request }) => {
     // create a flow to test with
     await prisma.dBFlowchart.deleteMany({


### PR DESCRIPTION
This PR removes the need to use the monolithic `apiData` object for user data mutation tasks. This is the last task required to remove the use of `apiData` when the app server is running (#2).

The primary change made here is that due to the removal of `apiData` when mutating user data (e.g. `/api/user/data/updateUserFlowcharts`), we need to fetch/generate the `programCache` and `courseCache` each time (so 2 DB calls - one for user flowcharts+program metadata, and one for the `courseCache`). A new utility, `generateCourseCacheFromUpdateChunks()`, is created to generate a `courseCache` only from the courses specified in the update chunks.

Tests were modified and updated to test new functionality.

