### PR TITLE
Disable initialization of apiData on app startup

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -6,10 +6,12 @@ import type { Handle, RequestEvent, HandleServerError } from '@sveltejs/kit';
 const logger = initLogger('Hooks');
 
 // initialize environment
-await loadEnv().catch((err) => {
-  logger.error('An error occurred during environment initialization', err);
+try {
+  loadEnv();
+} catch (error) {
+  logger.error('An error occurred during environment initialization', error);
   process.exit(-1);
-});
+}
 
 export const handle: Handle = async ({ event, resolve }) => {
   await setSession(event);

--- a/src/lib/server/config/envConfig.ts
+++ b/src/lib/server/config/envConfig.ts
@@ -1,6 +1,5 @@
 import dotenv from 'dotenv';
 import * as nodeMailerConfig from '$lib/server/config/nodeMailerConfig';
-import * as apiDataConfig from '$lib/server/config/apiDataConfig';
 import { execSync } from 'child_process';
 import { initLogger } from '$lib/common/config/loggerConfig';
 
@@ -11,7 +10,7 @@ export let FULL_VERSION_STRING = 'unknown';
 // session max age in seconds
 export const SESSION_MAX_AGE = 60 * 60 * 24;
 
-export async function loadEnv(): Promise<void> {
+export function loadEnv() {
   // env stuff specific to server
   try {
     const commit = execSync('git rev-parse --short HEAD').toString().slice(0, -1);
@@ -38,7 +37,6 @@ export async function loadEnv(): Promise<void> {
 
   // setup things that depend on env vars here
   nodeMailerConfig.init();
-  await apiDataConfig.init();
 
   logger.info('PolyFlowBuilder environment initialization complete');
 }


### PR DESCRIPTION
This PR disables the initialization of `apiData` when the PolyFlowBuilder server is started. This is the PR that will complete #2.