### PR TITLE
Add GitHub and Discord Logos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "zod": "^3.20.2"
       },
       "devDependencies": {
+        "@fortawesome/free-brands-svg-icons": "^6.4.2",
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@playwright/test": "^1.28.1",
         "@simonwep/pickr": "^1.8.2",
@@ -649,6 +650,19 @@
       "integrity": "sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA==",
       "dev": true,
       "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.2.tgz",
+      "integrity": "sha512-LKOwJX0I7+mR/cvvf6qIiqcERbdnY+24zgpUSouySml+5w8B4BJOx8EhDR/FTKAu06W12fmUIcv6lzPSwYKGGg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      },
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prepare": "husky install"
   },
   "devDependencies": {
+    "@fortawesome/free-brands-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@playwright/test": "^1.28.1",
     "@simonwep/pickr": "^1.8.2",

--- a/src/lib/components/common/Header.svelte
+++ b/src/lib/components/common/Header.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import Fa from 'svelte-fa';
   import { page } from '$app/stores';
+  import { faGithub } from '@fortawesome/free-brands-svg-icons';
   import { goto, invalidateAll } from '$app/navigation';
+  import { PUBLIC_PFB_GITHUB_LINK } from '$env/static/public';
   import { faBell, faBars, faSignOutAlt, faUserTimes } from '@fortawesome/free-solid-svg-icons';
 
   async function logout(deleteAcc = false) {
@@ -124,6 +126,13 @@
         </ul>
       </div>
     {:else}
+      <a
+        href={PUBLIC_PFB_GITHUB_LINK}
+        target="_blank"
+        class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
+      >
+        <Fa icon={faGithub} scale={1.8} />
+      </a>
       <a href="/login" class="btn btn-outline btn-md rounded-btn mr-3"> Sign In </a>
       <a href="/register" class="btn btn-outline btn-accent btn-md rounded-btn mr-4">
         Create Account

--- a/src/lib/components/common/Header.svelte
+++ b/src/lib/components/common/Header.svelte
@@ -84,14 +84,14 @@
       <a
         href={PUBLIC_PFB_DISCORD_LINK}
         target="_blank"
-        class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
+        class="btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
       >
         <Fa icon={faDiscord} scale={1.8} />
       </a>
       <a
         href={PUBLIC_PFB_GITHUB_LINK}
         target="_blank"
-        class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
+        class="mr-0.5 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
       >
         <Fa icon={faGithub} scale={1.8} />
       </a>

--- a/src/lib/components/common/Header.svelte
+++ b/src/lib/components/common/Header.svelte
@@ -74,6 +74,20 @@
     </div>
   </div>
   <div class="flex">
+    <a
+      href={PUBLIC_PFB_DISCORD_LINK}
+      target="_blank"
+      class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
+    >
+      <Fa icon={faDiscord} scale={1.8} />
+    </a>
+    <a
+      href={PUBLIC_PFB_GITHUB_LINK}
+      target="_blank"
+      class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
+    >
+      <Fa icon={faGithub} scale={1.8} />
+    </a>
     {#if $page.data.session}
       <div class="indicator">
         <!-- TODO: reimplement alert indicator when adding notifications -->
@@ -126,20 +140,6 @@
         </ul>
       </div>
     {:else}
-      <a
-        href={PUBLIC_PFB_DISCORD_LINK}
-        target="_blank"
-        class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
-      >
-        <Fa icon={faDiscord} scale={1.8} />
-      </a>
-      <a
-        href={PUBLIC_PFB_GITHUB_LINK}
-        target="_blank"
-        class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
-      >
-        <Fa icon={faGithub} scale={1.8} />
-      </a>
       <a href="/login" class="btn btn-outline btn-md rounded-btn mr-3"> Sign In </a>
       <a href="/register" class="btn btn-outline btn-accent btn-md rounded-btn mr-4">
         Create Account

--- a/src/lib/components/common/Header.svelte
+++ b/src/lib/components/common/Header.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import Fa from 'svelte-fa';
   import { page } from '$app/stores';
-  import { faGithub } from '@fortawesome/free-brands-svg-icons';
+  import { faGithub, faDiscord } from '@fortawesome/free-brands-svg-icons';
   import { goto, invalidateAll } from '$app/navigation';
-  import { PUBLIC_PFB_GITHUB_LINK } from '$env/static/public';
+  import { PUBLIC_PFB_DISCORD_LINK, PUBLIC_PFB_GITHUB_LINK } from '$env/static/public';
   import { faBell, faBars, faSignOutAlt, faUserTimes } from '@fortawesome/free-solid-svg-icons';
 
   async function logout(deleteAcc = false) {
@@ -126,6 +126,13 @@
         </ul>
       </div>
     {:else}
+      <a
+        href={PUBLIC_PFB_DISCORD_LINK}
+        target="_blank"
+        class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
+      >
+        <Fa icon={faDiscord} scale={1.8} />
+      </a>
       <a
         href={PUBLIC_PFB_GITHUB_LINK}
         target="_blank"

--- a/src/lib/components/common/Header.svelte
+++ b/src/lib/components/common/Header.svelte
@@ -54,10 +54,16 @@
       <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
       <ul tabindex="0" class="menu dropdown-content mt-2 p-2 shadow bg-base-100 w-52">
         <li class="text-gray-600">
-          <a href="/about" class="relative"> About </a>
+          <a href="/about" class="relative">About</a>
         </li>
         <li class="text-gray-600">
-          <a href="/feedback" class="relative"> Submit Feedback </a>
+          <a href="/feedback" class="relative">Submit Feedback</a>
+        </li>
+        <li class="text-gray-600">
+          <a href={PUBLIC_PFB_DISCORD_LINK} class="relative">Discord Server</a>
+        </li>
+        <li class="text-gray-600">
+          <a href={PUBLIC_PFB_GITHUB_LINK} class="relative">GitHub Repository</a>
         </li>
       </ul>
     </div>
@@ -74,20 +80,22 @@
     </div>
   </div>
   <div class="flex">
-    <a
-      href={PUBLIC_PFB_DISCORD_LINK}
-      target="_blank"
-      class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
-    >
-      <Fa icon={faDiscord} scale={1.8} />
-    </a>
-    <a
-      href={PUBLIC_PFB_GITHUB_LINK}
-      target="_blank"
-      class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
-    >
-      <Fa icon={faGithub} scale={1.8} />
-    </a>
+    <div class="hidden lg:inline">
+      <a
+        href={PUBLIC_PFB_DISCORD_LINK}
+        target="_blank"
+        class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
+      >
+        <Fa icon={faDiscord} scale={1.8} />
+      </a>
+      <a
+        href={PUBLIC_PFB_GITHUB_LINK}
+        target="_blank"
+        class="hidden xs:inline-flex mr-2 btn btn-md btn-ghost rounded-full hover:bg-gray-300 text-gray-600 transition"
+      >
+        <Fa icon={faGithub} scale={1.8} />
+      </a>
+    </div>
     {#if $page.data.session}
       <div class="indicator">
         <!-- TODO: reimplement alert indicator when adding notifications -->


### PR DESCRIPTION
This PR adds GitHub and Discord logos and links to the PolyFlowBuilder site.

No additional tests are necessary, and all existing tests pass.