### PR TITLE
Add Welcome Modal

### DIFF
--- a/src/lib/client/stores/modalStateStore.ts
+++ b/src/lib/client/stores/modalStateStore.ts
@@ -1,8 +1,12 @@
 // where modal state will be stored
 import { writable } from 'svelte/store';
 
+// functional Flows modals
 export const newFlowModalOpen = writable(false);
 export const addTermsModalOpen = writable(false);
 export const deleteTermsModalOpen = writable(false);
 export const editFlowPropertiesModalOpen = writable(false);
 export const customizeCoursesModalOpen = writable(false);
+
+// information Flows modals
+export const welcomeModalOpen = writable(false);

--- a/src/lib/components/Flows/modals/ModalWrapper.svelte
+++ b/src/lib/components/Flows/modals/ModalWrapper.svelte
@@ -4,7 +4,8 @@
     AddTermsModal,
     DeleteTermsModal,
     EditFlowPropertiesModal,
-    CustomizeCourseModal
+    CustomizeCourseModal,
+    WelcomeModal
   } from '$lib/components/Flows/modals';
 </script>
 
@@ -14,4 +15,5 @@
   <DeleteTermsModal />
   <EditFlowPropertiesModal />
   <CustomizeCourseModal />
+  <WelcomeModal />
 </div>

--- a/src/lib/components/Flows/modals/WelcomeModal.svelte
+++ b/src/lib/components/Flows/modals/WelcomeModal.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
-  import { PUBLIC_PFB_DISCORD_LINK, PUBLIC_PFB_GITHUB_LINK } from '$env/static/public';
-  import { welcomeModalOpen } from '$lib/client/stores/modalStateStore';
   import { modal } from '$lib/client/util/modalUtil';
+  import { onMount } from 'svelte';
+  import { welcomeModalOpen } from '$lib/client/stores/modalStateStore';
+  import { PUBLIC_PFB_DISCORD_LINK, PUBLIC_PFB_GITHUB_LINK } from '$env/static/public';
+
+  onMount(() => {
+    const modalSeen = localStorage.getItem('pfb_welcomeModalOpened');
+    if (modalSeen !== 'true') {
+      $welcomeModalOpen = true;
+    }
+  });
 
   function closeModal() {
     $welcomeModalOpen = false;
+    localStorage.setItem('pfb_welcomeModalOpened', 'true');
   }
 </script>
 

--- a/src/lib/components/Flows/modals/WelcomeModal.svelte
+++ b/src/lib/components/Flows/modals/WelcomeModal.svelte
@@ -21,8 +21,11 @@
       </p>
       <p class="mb-4">
         PolyFlowBuilder has been rewritten from the ground up to allow the project to grow, scale,
-        and be more organized for years to come. The previous version of PolyFlowBuilder was
-        something thrown together as a summer project and it's frankly a miracle it has been stable
+        and be more organized for years to come. The <a
+          href="https://old.polyflowbuilder.io"
+          class="hyperlink"
+          target="_blank">original version of PolyFlowBuilder</a
+        > was something thrown together as a summer project and it's frankly a miracle it has been stable
         for as long as it has.
       </p>
       <p class="mb-4">

--- a/src/lib/components/Flows/modals/WelcomeModal.svelte
+++ b/src/lib/components/Flows/modals/WelcomeModal.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { PUBLIC_PFB_DISCORD_LINK, PUBLIC_PFB_GITHUB_LINK } from '$env/static/public';
+  import { welcomeModalOpen } from '$lib/client/stores/modalStateStore';
+  import { modal } from '$lib/client/util/modalUtil';
+
+  function closeModal() {
+    $welcomeModalOpen = false;
+  }
+</script>
+
+<dialog use:modal={welcomeModalOpen} class="modal">
+  <div class="modal-box">
+    <h2 class="text-3xl font-medium text-polyGreen text-center">Welcome to PolyFlowBuilder!</h2>
+
+    <div class="divider" />
+
+    <div>
+      <p class="mb-4">
+        It appears that this is your first time using PolyFlowBuilder on this device. Welcome to the
+        PolyFlowBuilder community!
+      </p>
+      <p class="mb-4">
+        PolyFlowBuilder has been rewritten from the ground up to allow the project to grow, scale,
+        and be more organized for years to come. The previous version of PolyFlowBuilder was
+        something I threw together as a summer project and it's frankly a miracle it's been stable
+        for as long as it has.
+      </p>
+      <p class="mb-4">
+        Also note that PolyFlowBuilder has been made open source to ensure the project's longevitiy!
+        Click on the GitHub icon in the top-right of the screen to view the source code for the
+        project.
+      </p>
+      <p class="mb-4">
+        New features will continue to be developed for PolyFlowBuilder going forward. If you have
+        any questions, bug reports, feature requests, or any other feedback/comments about the
+        project, feel free to reach out and/or get involved via the following channels:
+      </p>
+      <ul class="list-decimal list-inside mb-4">
+        <li>
+          Project Contributions: <a href={PUBLIC_PFB_GITHUB_LINK} class="hyperlink" target="_blank"
+            >GitHub</a
+          >
+        </li>
+        <li>
+          PolyFlowBuilder Discord Server: <a
+            href={PUBLIC_PFB_DISCORD_LINK}
+            class="hyperlink"
+            target="_blank">Discord Server</a
+          >
+        </li>
+        <li>
+          PolyFlowBuilder Official Feedback Form: <a
+            href="/feedback"
+            class="hyperlink"
+            target="_blank">Feedback Form</a
+          >
+        </li>
+      </ul>
+      <p class="mb-4">
+        Thank you so much to everyone who has contributed to PolyFlowBuilder's development and
+        growth thus far, and thank YOU for using PolyFlowBuilder! I hope this tool is able to help
+        you on your academic journey at Cal Poly, SLO. 😄
+      </p>
+      <p class="mb-4">- Duncan A, PolyFlowBuilder Core Maintainer</p>
+
+      <p class="mb-4 text-center text-xs text-gray-500">
+        (view this message again by clicking on the user icon in the top-right icon and selecting
+        "View Welcome Message")
+      </p>
+    </div>
+
+    <button class="btn btn-almostmd w-full" on:click={closeModal}> Close </button>
+  </div>
+</dialog>
+
+<style lang="postcss">
+  /* expand modal size */
+  .modal-box {
+    max-width: 48rem;
+  }
+</style>

--- a/src/lib/components/Flows/modals/WelcomeModal.svelte
+++ b/src/lib/components/Flows/modals/WelcomeModal.svelte
@@ -22,7 +22,7 @@
       <p class="mb-4">
         PolyFlowBuilder has been rewritten from the ground up to allow the project to grow, scale,
         and be more organized for years to come. The previous version of PolyFlowBuilder was
-        something I threw together as a summer project and it's frankly a miracle it's been stable
+        something thrown together as a summer project and it's frankly a miracle it has been stable
         for as long as it has.
       </p>
       <p class="mb-4">
@@ -64,8 +64,8 @@
       <p class="mb-4">- Duncan A, PolyFlowBuilder Core Maintainer</p>
 
       <p class="mb-4 text-center text-xs text-gray-500">
-        (view this message again by clicking on the user icon in the top-right icon and selecting
-        "View Welcome Message")
+        (view this message again by clicking on your user icon in the top-right and selecting "View
+        Welcome Message")
       </p>
     </div>
 

--- a/src/lib/components/Flows/modals/index.ts
+++ b/src/lib/components/Flows/modals/index.ts
@@ -1,18 +1,18 @@
+import WelcomeModal from './WelcomeModal.svelte';
 import NewFlowModal from './NewFlowModal.svelte';
 import AddTermsModal from './AddTermsModal.svelte';
 import DeleteTermsModal from './DeleteTermsModal.svelte';
 import EditFlowPropertiesModal from './EditFlowPropertiesModal.svelte';
 import CustomizeCourseModal from './CustomizeCourseModal.svelte';
-import WelcomeModal from './WelcomeModal.svelte';
 
 import ModalWrapper from './ModalWrapper.svelte';
 
 export {
+  WelcomeModal,
   NewFlowModal,
   AddTermsModal,
   DeleteTermsModal,
   EditFlowPropertiesModal,
   CustomizeCourseModal,
-  WelcomeModal,
   ModalWrapper
 };

--- a/src/lib/components/Flows/modals/index.ts
+++ b/src/lib/components/Flows/modals/index.ts
@@ -3,6 +3,7 @@ import AddTermsModal from './AddTermsModal.svelte';
 import DeleteTermsModal from './DeleteTermsModal.svelte';
 import EditFlowPropertiesModal from './EditFlowPropertiesModal.svelte';
 import CustomizeCourseModal from './CustomizeCourseModal.svelte';
+import WelcomeModal from './WelcomeModal.svelte';
 
 import ModalWrapper from './ModalWrapper.svelte';
 
@@ -12,5 +13,6 @@ export {
   DeleteTermsModal,
   EditFlowPropertiesModal,
   CustomizeCourseModal,
+  WelcomeModal,
   ModalWrapper
 };

--- a/src/lib/components/common/Header.svelte
+++ b/src/lib/components/common/Header.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   import Fa from 'svelte-fa';
   import { page } from '$app/stores';
+  import { welcomeModalOpen } from '$lib/client/stores/modalStateStore';
   import { faGithub, faDiscord } from '@fortawesome/free-brands-svg-icons';
   import { goto, invalidateAll } from '$app/navigation';
   import { PUBLIC_PFB_DISCORD_LINK, PUBLIC_PFB_GITHUB_LINK } from '$env/static/public';
-  import { faBell, faBars, faSignOutAlt, faUserTimes } from '@fortawesome/free-solid-svg-icons';
+  import {
+    faBell,
+    faBars,
+    faDoorOpen,
+    faUserTimes,
+    faSignOutAlt
+  } from '@fortawesome/free-solid-svg-icons';
 
   async function logout(deleteAcc = false) {
     try {
@@ -133,6 +140,16 @@
             </div>
           </li>
           <div class="divider m-0 p-0" />
+          <li class="text-gray-800">
+            <a
+              href={'#'}
+              class="relative"
+              on:click|preventDefault={() => ($welcomeModalOpen = true)}
+            >
+              View Welcome Message
+              <Fa icon={faDoorOpen} class="right-4 absolute" />
+            </a>
+          </li>
           <li class="text-gray-800">
             <a href={'#'} class="relative" on:click|preventDefault={() => logout()}>
               Log Out

--- a/src/lib/components/common/Header.svelte
+++ b/src/lib/components/common/Header.svelte
@@ -141,16 +141,6 @@
           </li>
           <div class="divider m-0 p-0" />
           <li class="text-gray-800">
-            <a
-              href={'#'}
-              class="relative"
-              on:click|preventDefault={() => ($welcomeModalOpen = true)}
-            >
-              View Welcome Message
-              <Fa icon={faDoorOpen} class="right-4 absolute" />
-            </a>
-          </li>
-          <li class="text-gray-800">
             <a href={'#'} class="relative" on:click|preventDefault={() => logout()}>
               Log Out
               <Fa icon={faSignOutAlt} class="right-4 absolute text-green-500" />
@@ -160,6 +150,17 @@
             <a href={'#'} class="relative" on:click|preventDefault={() => logout(true)}>
               Delete Account
               <Fa icon={faUserTimes} class="right-3 absolute text-red-500" />
+            </a>
+          </li>
+          <div class="divider m-0 p-0" />
+          <li class="text-gray-800">
+            <a
+              href={'#'}
+              class="relative"
+              on:click|preventDefault={() => ($welcomeModalOpen = true)}
+            >
+              View Welcome Message
+              <Fa icon={faDoorOpen} class="right-4 absolute" />
             </a>
           </li>
         </ul>

--- a/tests/api/generateFlowchartApiTests.test.ts
+++ b/tests/api/generateFlowchartApiTests.test.ts
@@ -1,10 +1,10 @@
 import crypto from 'crypto';
 import { expect, test } from '@playwright/test';
-import { performLoginBackend } from '../util/userTestUtil.js';
+import { performLoginBackend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { flowchartValidationSchema } from '$lib/common/schema/flowchartSchema';
 import { CURRENT_FLOW_DATA_VERSION, FLOW_NAME_MAX_LENGTH } from '$lib/common/config/flowDataConfig';
-import { cloneAndDeleteNestedProperty, deleteObjectProperties } from '../util/testUtil.js';
+import { cloneAndDeleteNestedProperty, deleteObjectProperties } from 'tests/util/testUtil.js';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache } from '$lib/types/apiDataTypes.js';
 

--- a/tests/api/getUserFlowchartsTests.test.ts
+++ b/tests/api/getUserFlowchartsTests.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
-import { performLoginBackend } from '../util/userTestUtil.js';
+import { performLoginBackend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig.js';
-import { cloneAndDeleteNestedProperty } from '../util/testUtil.js';
+import { cloneAndDeleteNestedProperty } from 'tests/util/testUtil.js';
 
 const GET_USER_FLOWCHARTS_TESTS_API_EMAIL = 'pfb_test_getUserFlowchartsAPI_playwright@test.com';
 

--- a/tests/api/resetPasswordApiTests.test.ts
+++ b/tests/api/resetPasswordApiTests.test.ts
@@ -1,4 +1,4 @@
-import { createToken } from '../util/tokenTestUtil.js';
+import { createToken } from 'tests/util/tokenTestUtil.js';
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { createUser, deleteUser } from '$lib/server/db/user';

--- a/tests/api/searchCatalogApiTests.test.ts
+++ b/tests/api/searchCatalogApiTests.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { performLoginBackend } from '../util/userTestUtil.js';
+import { performLoginBackend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 
 const SEARCH_CATALOG_API_TESTS_EMAIL = 'pfb_test_searchCatalogAPI_playwright@test.com';

--- a/tests/api/updateUserFlowchartsApiTests/flowDeleteApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowDeleteApiTests.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from '../../util/userDataTestUtil.js';
-import { performLoginBackend } from '../../util/userTestUtil.js';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
+import { performLoginBackend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes.js';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';

--- a/tests/api/updateUserFlowchartsApiTests/flowListChangeApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowListChangeApiTests.test.ts
@@ -1,13 +1,13 @@
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
-import { populateFlowcharts } from '../../util/userDataTestUtil.js';
-import { performLoginBackend } from '../../util/userTestUtil.js';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
+import { performLoginBackend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
-import type { MutateFlowchartData } from '$lib/types/mutateUserDataTypes';
 import type { CourseCache } from '$lib/types/apiDataTypes.js';
+import type { MutateFlowchartData } from '$lib/types/mutateUserDataTypes';
 
 const FLOW_LIST_CHANGE_TESTS_API_EMAIL =
   'pfb_test_updateUserFlowchartsAPI_FLOW_LIST_CHANGE_playwright@test.com';

--- a/tests/api/updateUserFlowchartsApiTests/flowTermModApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowTermModApiTests.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from '../../util/userDataTestUtil.js';
-import { performLoginBackend } from '../../util/userTestUtil.js';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
+import { performLoginBackend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import {
-  UserDataUpdateChunkTERM_MODCourseDataFrom,
-  UserDataUpdateChunkType
+  UserDataUpdateChunkType,
+  UserDataUpdateChunkTERM_MODCourseDataFrom
 } from '$lib/types/mutateUserDataTypes.js';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema.js';
 import type { CourseCache } from '$lib/types/apiDataTypes.js';

--- a/tests/api/updateUserFlowchartsApiTests/flowUpsertAllApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowUpsertAllApiTests.test.ts
@@ -1,8 +1,8 @@
 import { v4 as uuid } from 'uuid';
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
-import { populateFlowcharts } from '../../util/userDataTestUtil.js';
-import { performLoginBackend } from '../../util/userTestUtil.js';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
+import { performLoginBackend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes.js';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig.js';

--- a/tests/api/updateUserFlowchartsApiTests/updateUserFlowchartsApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/updateUserFlowchartsApiTests.test.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
-import { performLoginBackend } from '../../util/userTestUtil.js';
+import { performLoginBackend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig.js';

--- a/tests/bugfix/gh-issue-38.test.ts
+++ b/tests/bugfix/gh-issue-38.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
-import { createUser, deleteUser } from '$lib/server/db/user';
+import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
 import { performLoginFrontend } from 'tests/util/userTestUtil';
+import { createUser, deleteUser } from '$lib/server/db/user';
 
 // bug description: modals fail to open when navigating to the
 // flow editor for the second time (e.g. first time works, then navigate away,
@@ -19,6 +20,7 @@ test.describe('gh-issue-38 bugfix tests', () => {
   });
 
   test.beforeEach(async ({ page }) => {
+    await skipWelcomeMessage(page);
     await performLoginFrontend(page, GH_ISSUE_38_TESTS_EMAIL, 'test');
   });
 

--- a/tests/misc/authGuardTests.test.ts
+++ b/tests/misc/authGuardTests.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { performLoginFrontend } from '../util/userTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import type { Page } from '@playwright/test';
 

--- a/tests/page/flows/addFlowTermsTests.test.ts
+++ b/tests/page/flows/addFlowTermsTests.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 import { performLoginFrontend } from '../../util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
+import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
 import { PrismaClient } from '@prisma/client';
 import {
@@ -241,6 +242,7 @@ test.describe('add flowchart terms tests', () => {
   });
 
   test.beforeEach(async ({ page }) => {
+    await skipWelcomeMessage(page);
     await performLoginFrontend(page, FLOWS_PAGE_ADD_TERMS_MODAL_TESTS_EMAIL, 'test');
   });
 

--- a/tests/page/flows/addFlowTermsTests.test.ts
+++ b/tests/page/flows/addFlowTermsTests.test.ts
@@ -1,14 +1,15 @@
-import { expect, test, type Page } from '@playwright/test';
-import { performLoginFrontend } from '../../util/userTestUtil.js';
-import { createUser, deleteUser } from '$lib/server/db/user';
+import { expect, test } from '@playwright/test';
+import { PrismaClient } from '@prisma/client';
 import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
-import { PrismaClient } from '@prisma/client';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
+import { createUser, deleteUser } from '$lib/server/db/user';
 import {
   FLOW_LIST_ITEM_SELECTOR,
-  TERM_CONTAINER_COURSES_SELECTOR,
-  TERM_CONTAINER_SELECTOR
+  TERM_CONTAINER_SELECTOR,
+  TERM_CONTAINER_COURSES_SELECTOR
 } from 'tests/util/selectorTestUtil.js';
+import type { Page } from '@playwright/test';
 
 const FLOWS_PAGE_ADD_TERMS_MODAL_TESTS_EMAIL =
   'pfb_test_flowsPage_add_terms_modal_playwright@test.com';

--- a/tests/page/flows/deleteFlowTests.test.ts
+++ b/tests/page/flows/deleteFlowTests.test.ts
@@ -2,13 +2,13 @@ import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
 import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
-import { populateFlowcharts } from '../../util/userDataTestUtil.js';
-import { performLoginFrontend } from '../../util/userTestUtil.js';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import {
-  FLOW_LIST_ITEM_SELECTED_SELECTOR,
-  FLOW_LIST_ITEM_SELECTOR
-} from '../../util/selectorTestUtil.js';
+  FLOW_LIST_ITEM_SELECTOR,
+  FLOW_LIST_ITEM_SELECTED_SELECTOR
+} from 'tests/util/selectorTestUtil.js';
 import type { Page } from '@playwright/test';
 
 const FLOWS_PAGE_DELETE_FLOW_TESTS_EMAIL = 'pfb_test_flowPage_deleteFlow_playwright@test.com';

--- a/tests/page/flows/deleteFlowTests.test.ts
+++ b/tests/page/flows/deleteFlowTests.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
+import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import { populateFlowcharts } from '../../util/userDataTestUtil.js';
 import { performLoginFrontend } from '../../util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
@@ -104,6 +105,10 @@ test.describe('flow delete tests', () => {
 
     // create flowcharts to mess around in
     await populateFlowcharts(prisma, userId, 4);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await skipWelcomeMessage(page);
   });
 
   test.afterAll(async () => {

--- a/tests/page/flows/flowListTests.test.ts
+++ b/tests/page/flows/flowListTests.test.ts
@@ -1,9 +1,9 @@
-import { dragAndDrop } from '../../util/frontendInteractionUtil.js';
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { populateFlowcharts } from '../../util/userDataTestUtil.js';
 import { performLoginFrontend } from '../../util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
+import { dragAndDrop, skipWelcomeMessage } from '../../util/frontendInteractionUtil.js';
 import {
   FLOW_LIST_ITEM_SELECTED_SELECTOR,
   FLOW_LIST_ITEM_SELECTOR
@@ -30,6 +30,7 @@ test.describe('flow list tests', () => {
   });
 
   test.beforeEach(async ({ page }) => {
+    await skipWelcomeMessage(page);
     await prisma.dBFlowchart.deleteMany({
       where: {
         ownerId: userId

--- a/tests/page/flows/flowListTests.test.ts
+++ b/tests/page/flows/flowListTests.test.ts
@@ -1,13 +1,13 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from '../../util/userDataTestUtil.js';
-import { performLoginFrontend } from '../../util/userTestUtil.js';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { dragAndDrop, skipWelcomeMessage } from '../../util/frontendInteractionUtil.js';
+import { dragAndDrop, skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import {
-  FLOW_LIST_ITEM_SELECTED_SELECTOR,
-  FLOW_LIST_ITEM_SELECTOR
-} from '../../util/selectorTestUtil.js';
+  FLOW_LIST_ITEM_SELECTOR,
+  FLOW_LIST_ITEM_SELECTED_SELECTOR
+} from 'tests/util/selectorTestUtil.js';
 
 const FLOWS_PAGE_FLOW_LIST_TESTS_EMAIL = 'pfb_test_flowsPage_flow_list_playwright@test.com';
 

--- a/tests/page/flows/flowViewerTests.test.ts
+++ b/tests/page/flows/flowViewerTests.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
+import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import { populateFlowcharts } from '../../util/userDataTestUtil.js';
 import { performLoginFrontend } from '../../util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
@@ -35,6 +36,10 @@ test.describe('flowchart viewer tests', () => {
         }
       }
     ]);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await skipWelcomeMessage(page);
   });
 
   test.afterAll(async () => {

--- a/tests/page/flows/flowViewerTests.test.ts
+++ b/tests/page/flows/flowViewerTests.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
-import { populateFlowcharts } from '../../util/userDataTestUtil.js';
-import { performLoginFrontend } from '../../util/userTestUtil.js';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { FLOW_LIST_ITEM_SELECTOR } from '../../util/selectorTestUtil.js';
+import { FLOW_LIST_ITEM_SELECTOR } from 'tests/util/selectorTestUtil.js';
 
 const FLOWS_PAGE_FLOW_VIEWER_TESTS_EMAIL = 'pfb_test_flowPage_flowViewer_playwright@test.com';
 

--- a/tests/page/flows/headerTests.test.ts
+++ b/tests/page/flows/headerTests.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
-import { performLoginFrontend } from '../../util/userTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import type { Page } from '@playwright/test';
 

--- a/tests/page/flows/headerTests.test.ts
+++ b/tests/page/flows/headerTests.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
+import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import { performLoginFrontend } from '../../util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import type { Page } from '@playwright/test';
@@ -22,6 +23,7 @@ test.describe('flows page header tests', () => {
     // login
     // see https://playwright.dev/docs/auth#reuse-the-signed-in-page-in-multiple-tests
     page = await browser.newPage();
+    await skipWelcomeMessage(page);
     await performLoginFrontend(page, FLOWS_PAGE_HEADER_TESTS_EMAIL, 'test');
   });
 

--- a/tests/page/flows/modals/newFlowModalTests.test.ts
+++ b/tests/page/flows/modals/newFlowModalTests.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import { performLoginFrontend } from '../../../util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import type { Page } from '@playwright/test';
@@ -28,6 +29,7 @@ test.describe('new flow modal tests', () => {
   });
 
   test.beforeEach(async ({ page }) => {
+    await skipWelcomeMessage(page);
     await performLoginFrontend(page, FLOWS_PAGE_NEW_FLOW_MODAL_TESTS_EMAIL, 'test');
   });
 

--- a/tests/page/flows/modals/newFlowModalTests.test.ts
+++ b/tests/page/flows/modals/newFlowModalTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
-import { performLoginFrontend } from '../../../util/userTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import type { Page } from '@playwright/test';
 

--- a/tests/page/flows/modals/welcomeModalTests.test.ts
+++ b/tests/page/flows/modals/welcomeModalTests.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+import { performLoginFrontend } from '../../../util/userTestUtil';
+import { createUser, deleteUser } from '$lib/server/db/user';
+
+const FLOWS_PAGE_MODAL_WELCOME_TESTS_EMAIL = 'pfb_test_flowsPage_modal_welcome_playwright@test.com';
+
+test.describe('welcome modal tests', () => {
+  test.beforeAll(async () => {
+    // create account
+    await createUser({
+      email: FLOWS_PAGE_MODAL_WELCOME_TESTS_EMAIL,
+      username: 'test',
+      password: 'test'
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await performLoginFrontend(page, FLOWS_PAGE_MODAL_WELCOME_TESTS_EMAIL, 'test');
+  });
+
+  test.afterAll(async () => {
+    await deleteUser(FLOWS_PAGE_MODAL_WELCOME_TESTS_EMAIL);
+  });
+
+  test('modal appears on first login and then does not reappear', async ({ page }) => {
+    // expect modal to be visible
+    await expect(page.getByText('Welcome to PolyFlowBuilder!')).toBeVisible();
+    await expect(page.getByText('Welcome to PolyFlowBuilder!')).toBeInViewport();
+
+    // then close
+    await page.getByRole('button', { name: 'Close' }).click();
+
+    // reload and expect modal to not be visible
+    await page.reload();
+
+    await expect(page.getByText('Welcome to PolyFlowBuilder!')).not.toBeVisible();
+  });
+
+  test('modal does not appear when localStorage key is set', async ({ page }) => {
+    // set localstorage key
+    await page.evaluate(() => {
+      window.localStorage.setItem('pfb_welcomeModalOpened', 'true');
+    });
+
+    // reload and expect modal to not be visible
+    await page.reload();
+
+    await expect(page.getByText('Welcome to PolyFlowBuilder!')).not.toBeVisible();
+  });
+
+  test('user able to open modal again after closing', async ({ page }) => {
+    // expect modal to be visible
+    await expect(page.getByText('Welcome to PolyFlowBuilder!')).toBeVisible();
+    await expect(page.getByText('Welcome to PolyFlowBuilder!')).toBeInViewport();
+
+    // then close
+    await page.getByRole('button', { name: 'Close' }).click();
+
+    // then open again
+    await page.getByRole('img', { name: 'user' }).click();
+    await page.getByText('View Welcome Message', { exact: true }).click();
+
+    // expect modal to be visible again
+    await expect(page.getByText('Welcome to PolyFlowBuilder!')).toBeVisible();
+    await page.getByText('Welcome to PolyFlowBuilder!').scrollIntoViewIfNeeded();
+    await expect(page.getByText('Welcome to PolyFlowBuilder!')).toBeInViewport();
+  });
+});

--- a/tests/page/flows/modals/welcomeModalTests.test.ts
+++ b/tests/page/flows/modals/welcomeModalTests.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { performLoginFrontend } from '../../../util/userTestUtil';
+import { performLoginFrontend } from 'tests/util/userTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
 
 const FLOWS_PAGE_MODAL_WELCOME_TESTS_EMAIL = 'pfb_test_flowsPage_modal_welcome_playwright@test.com';

--- a/tests/page/flows/modals/welcomeModalTests.test.ts
+++ b/tests/page/flows/modals/welcomeModalTests.test.ts
@@ -47,22 +47,4 @@ test.describe('welcome modal tests', () => {
 
     await expect(page.getByText('Welcome to PolyFlowBuilder!')).not.toBeVisible();
   });
-
-  test('user able to open modal again after closing', async ({ page }) => {
-    // expect modal to be visible
-    await expect(page.getByText('Welcome to PolyFlowBuilder!')).toBeVisible();
-    await expect(page.getByText('Welcome to PolyFlowBuilder!')).toBeInViewport();
-
-    // then close
-    await page.getByRole('button', { name: 'Close' }).click();
-
-    // then open again
-    await page.getByRole('img', { name: 'user' }).click();
-    await page.getByText('View Welcome Message', { exact: true }).click();
-
-    // expect modal to be visible again
-    await expect(page.getByText('Welcome to PolyFlowBuilder!')).toBeVisible();
-    await page.getByText('Welcome to PolyFlowBuilder!').scrollIntoViewIfNeeded();
-    await expect(page.getByText('Welcome to PolyFlowBuilder!')).toBeInViewport();
-  });
 });

--- a/tests/page/flows/modifyFlowTermDataTests.test.ts
+++ b/tests/page/flows/modifyFlowTermDataTests.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from '../../util/userDataTestUtil.js';
-import { performLoginFrontend } from '../../util/userTestUtil.js';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { dragAndDrop, skipWelcomeMessage } from '../../util/frontendInteractionUtil.js';
+import { dragAndDrop, skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import {
   FLOW_LIST_ITEM_SELECTOR,
-  TERM_CONTAINER_COURSES_SELECTOR,
   TERM_CONTAINER_SELECTOR,
-  getTermContainerCourseLocator
-} from '../../util/selectorTestUtil.js';
+  getTermContainerCourseLocator,
+  TERM_CONTAINER_COURSES_SELECTOR
+} from 'tests/util/selectorTestUtil.js';
 
 // TODO: include tests that customize courses
 // TODO: include tests that add new courses to terms

--- a/tests/page/flows/modifyFlowTermDataTests.test.ts
+++ b/tests/page/flows/modifyFlowTermDataTests.test.ts
@@ -1,9 +1,9 @@
-import { dragAndDrop } from '../../util/frontendInteractionUtil.js';
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { populateFlowcharts } from '../../util/userDataTestUtil.js';
 import { performLoginFrontend } from '../../util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
+import { dragAndDrop, skipWelcomeMessage } from '../../util/frontendInteractionUtil.js';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   TERM_CONTAINER_COURSES_SELECTOR,
@@ -36,7 +36,8 @@ test.describe('FLOW_TERM_MOD update tests', () => {
     userId = id;
   });
 
-  test.beforeEach(async () => {
+  test.beforeEach(async ({ page }) => {
+    await skipWelcomeMessage(page);
     await prisma.dBFlowchart.deleteMany({
       where: {
         ownerId: userId

--- a/tests/page/flows/search/courseSearchOptionsSelectorTests.test.ts
+++ b/tests/page/flows/search/courseSearchOptionsSelectorTests.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
-import { populateFlowcharts } from '../../../util/userDataTestUtil.js';
-import { performLoginFrontend } from '../../../util/userTestUtil.js';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { FLOW_LIST_ITEM_SELECTOR } from '../../../util/selectorTestUtil.js';
+import { FLOW_LIST_ITEM_SELECTOR } from 'tests/util/selectorTestUtil.js';
 
 const FLOWS_PAGE_COURSE_SEARCH_OPTIONS_TESTS_EMAIL =
   'pfb_test_flowPage_courseSearchOptions_playwright@test.com';

--- a/tests/page/flows/search/courseSearchOptionsSelectorTests.test.ts
+++ b/tests/page/flows/search/courseSearchOptionsSelectorTests.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
+import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import { populateFlowcharts } from '../../../util/userDataTestUtil.js';
 import { performLoginFrontend } from '../../../util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
@@ -39,6 +40,10 @@ test.describe('CourseSearchOptionsSelector tests', () => {
         }
       }
     ]);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await skipWelcomeMessage(page);
   });
 
   test.afterAll(async () => {

--- a/tests/page/flows/search/courseSearchTests.test.ts
+++ b/tests/page/flows/search/courseSearchTests.test.ts
@@ -1,9 +1,9 @@
-import { dragAndDrop } from 'tests/util/frontendInteractionUtil.js';
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { populateFlowcharts } from '../../../util/userDataTestUtil.js';
 import { performLoginFrontend } from '../../../util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
+import { dragAndDrop, skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import {
   CATALOG_SEARCH_COURSES_SELECTOR,
   FLOW_LIST_ITEM_SELECTOR,
@@ -171,6 +171,10 @@ test.describe('course search tests', () => {
         }
       }
     ]);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await skipWelcomeMessage(page);
   });
 
   test.afterAll(async () => {

--- a/tests/page/flows/search/courseSearchTests.test.ts
+++ b/tests/page/flows/search/courseSearchTests.test.ts
@@ -1,14 +1,14 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from '../../../util/userDataTestUtil.js';
-import { performLoginFrontend } from '../../../util/userTestUtil.js';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { dragAndDrop, skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import {
-  CATALOG_SEARCH_COURSES_SELECTOR,
   FLOW_LIST_ITEM_SELECTOR,
-  getTermContainerCourseLocator
-} from '../../../util/selectorTestUtil.js';
+  getTermContainerCourseLocator,
+  CATALOG_SEARCH_COURSES_SELECTOR
+} from 'tests/util/selectorTestUtil.js';
 import type { Page } from '@playwright/test';
 import type { CatalogSearchValidFields } from '$lib/server/schema/searchCatalogSchema.js';
 

--- a/tests/page/homePageTests.test.ts
+++ b/tests/page/homePageTests.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { checkCarouselSlide } from '../util/homeCarouselTestUtil.js';
+import { checkCarouselSlide } from 'tests/util/homeCarouselTestUtil.js';
 
 test.describe('homepage tests', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/page/loginPageTests.test.ts
+++ b/tests/page/loginPageTests.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { performLoginFrontend } from '../util/userTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 
 const LOGIN_TESTS_EMAIL = 'pfb_test_loginPage_playwright@test.com';

--- a/tests/page/resetPasswordPageTests.test.ts
+++ b/tests/page/resetPasswordPageTests.test.ts
@@ -1,4 +1,4 @@
-import { createToken } from '../util/tokenTestUtil.js';
+import { createToken } from 'tests/util/tokenTestUtil.js';
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
 import { clearTokensByEmail } from '$lib/server/db/token';

--- a/tests/routine/createFlowRoutineTests.test.ts
+++ b/tests/routine/createFlowRoutineTests.test.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
+import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import { populateFlowcharts } from '../util/userDataTestUtil.js';
 import { performLoginFrontend } from '../util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
@@ -27,6 +28,10 @@ test.describe('create flow routine tests', () => {
 
     // create test flow to verify creation behavior in frontend
     await populateFlowcharts(prisma, id, 10);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await skipWelcomeMessage(page);
   });
 
   test.afterAll(async () => {

--- a/tests/routine/createFlowRoutineTests.test.ts
+++ b/tests/routine/createFlowRoutineTests.test.ts
@@ -1,10 +1,10 @@
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
 import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
-import { populateFlowcharts } from '../util/userDataTestUtil.js';
-import { performLoginFrontend } from '../util/userTestUtil.js';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { FLOW_LIST_ITEM_SELECTOR } from '../util/selectorTestUtil.js';
+import { FLOW_LIST_ITEM_SELECTOR } from 'tests/util/selectorTestUtil.js';
 
 // TODO: is this a "routine", or an "Action"? figure out what routine is and
 // reorganize the tests

--- a/tests/routine/resetPasswordRoutineTests.test.ts
+++ b/tests/routine/resetPasswordRoutineTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { performLoginFrontend } from '../util/userTestUtil.js';
+import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
 
 const RESET_PASSWORD_ROUTINE_TESTS_EMAIL = 'pfb_test_resetPasswordRoutine_playwright@test.com';

--- a/tests/util/frontendInteractionUtil.ts
+++ b/tests/util/frontendInteractionUtil.ts
@@ -56,3 +56,9 @@ export async function dragAndDrop(
   // if tests are not performing as expected, bump up timeout to let elements "settle" in headless mode
   await page.waitForTimeout(100);
 }
+
+export async function skipWelcomeMessage(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('pfb_welcomeModalOpened', 'true');
+  });
+}


### PR DESCRIPTION
This PR introduces a Welcome Modal that has some information about the project in it when the user first logs into the editor (navigates to the `/flows` page) on a new device (managed via `localStorage`). The user can also bring up the modal again by clicking on their avatar and clicking "View Welcome Message" in the dropdown.

Tests were added and updated to accommodate these changes.