### PR TITLE
Fix inability to add courses to empty terms

### DIFF
--- a/src/lib/components/common/MutableForEachContainer.svelte
+++ b/src/lib/components/common/MutableForEachContainer.svelte
@@ -95,7 +95,12 @@
 {/if}
 
 <style lang="postcss">
-  div.mutableForEachContainer {
+  /* need both containers to have full height 
+    so courses can be dragged into an empty term
+    (or else dndzone section is 0px tall with empty term)
+  */
+  div.mutableForEachContainer,
+  div.mutableForEachContainer section {
     /* allow scrolling */
     overflow: auto;
     height: 100%;

--- a/tests/page/flows/addFlowTermsTests.test.ts
+++ b/tests/page/flows/addFlowTermsTests.test.ts
@@ -1,12 +1,13 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import { populateFlowcharts } from 'tests/util/userDataTestUtil.js';
 import { performLoginFrontend } from 'tests/util/userTestUtil.js';
 import { createUser, deleteUser } from '$lib/server/db/user';
+import { dragAndDrop, skipWelcomeMessage } from 'tests/util/frontendInteractionUtil.js';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   TERM_CONTAINER_SELECTOR,
+  getTermContainerCourseLocator,
   TERM_CONTAINER_COURSES_SELECTOR
 } from 'tests/util/selectorTestUtil.js';
 import type { Page } from '@playwright/test';
@@ -402,6 +403,20 @@ test.describe('add flowchart terms tests', () => {
         'Spring 2027'
       ],
       ['Fall 2023']
+    );
+
+    // make sure we can move courses into the new term
+    await dragAndDrop(
+      page,
+      getTermContainerCourseLocator(page, [5, 0]),
+      page.locator(TERM_CONTAINER_SELECTOR).nth(6)
+    );
+
+    await expect(
+      page.locator(TERM_CONTAINER_SELECTOR).nth(6).locator(TERM_CONTAINER_COURSES_SELECTOR)
+    ).toHaveCount(1);
+    await expect(getTermContainerCourseLocator(page, [6, 0]).locator('h6')).toHaveText(
+      '0--- is the longestthis is the longestthis is the longestthis is the longestthis is the longestthis is the longestthis is the longestthis is the longe'
     );
   });
 

--- a/tests/page/flows/modifyFlowTermDataTests.test.ts
+++ b/tests/page/flows/modifyFlowTermDataTests.test.ts
@@ -399,4 +399,66 @@ test.describe('FLOW_TERM_MOD update tests', () => {
       '7-- is the longestthis is the longestthis is the longestthis is the longestthis is the longestthis is the longestthis is the longestthis is the longe'
     );
   });
+
+  test('move course to empty term', async ({ page }) => {
+    await performLoginFrontend(page, MODIFY_FLOW_TERM_DATA_TESTS_EMAIL, 'test');
+    await expect(page).toHaveURL(/.*flows/);
+    expect((await page.textContent('h2'))?.trim()).toBe('Flows');
+    expect((await page.context().cookies())[0].name).toBe('sId');
+
+    // load the flowchart
+    await expect(page.locator(FLOW_LIST_ITEM_SELECTOR)).toHaveCount(1);
+    await page.locator(FLOW_LIST_ITEM_SELECTOR).first().click();
+    await expect(
+      page.getByRole('heading', {
+        name: 'test flow 0'
+      })
+    ).toBeInViewport();
+
+    // verify initial order of courses in the first term
+    await expect(getTermContainerCourseLocator(page, [0, 0]).locator('h6')).toHaveText(
+      '0--- is the longestthis is the longestthis is the longestthis is the longestthis is the longestthis is the longestthis is the longestthis is the longe'
+    );
+    await expect(getTermContainerCourseLocator(page, [0, 1]).locator('h6')).toHaveText('MATH142');
+    await expect(getTermContainerCourseLocator(page, [0, 2]).locator('h6')).toHaveText('MATH153');
+    await expect(getTermContainerCourseLocator(page, [0, 3]).locator('h6')).toHaveText('MATH96');
+
+    // move courses out of the first term
+    await dragAndDrop(
+      page,
+      getTermContainerCourseLocator(page, [0, 0]),
+      getTermContainerCourseLocator(page, [1, 0])
+    );
+    await dragAndDrop(
+      page,
+      getTermContainerCourseLocator(page, [0, 0]),
+      getTermContainerCourseLocator(page, [1, 0])
+    );
+    await dragAndDrop(
+      page,
+      getTermContainerCourseLocator(page, [0, 0]),
+      getTermContainerCourseLocator(page, [1, 0])
+    );
+    await dragAndDrop(
+      page,
+      getTermContainerCourseLocator(page, [0, 0]),
+      getTermContainerCourseLocator(page, [1, 0]),
+      false
+    );
+
+    // verify first term is empty
+    await expect(
+      page.locator(TERM_CONTAINER_SELECTOR).nth(0).locator(TERM_CONTAINER_COURSES_SELECTOR)
+    ).toHaveCount(0);
+
+    // move course into empty term
+    await dragAndDrop(
+      page,
+      getTermContainerCourseLocator(page, [1, 0]),
+      page.locator(TERM_CONTAINER_SELECTOR).nth(0)
+    );
+
+    // verify course is in first term
+    await expect(getTermContainerCourseLocator(page, [0, 0]).locator('h6')).toHaveText('MATH96');
+  });
 });


### PR DESCRIPTION
This PR is a fix for issue #43, where users cannot add courses to empty terms.

Tests were augmented and updated to cover the use case of adding courses to empty terms (via search and via courses already existing in the flowchart).