### PR TITLE
Add analytics

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import '../app.postcss';
   import { Footer, Header } from '$lib/components/common';
+  import { PUBLIC_PFB_ANALYTICS_ID } from '$env/static/public';
 </script>
 
 <svelte:head>
@@ -17,7 +18,11 @@
   />
   <title>PolyFlowBuilder</title>
 
-  <!-- TODO: add Google Analytics -->
+  <script
+    async
+    src="https://analytics.polyflowbuilder.io/script.js"
+    data-website-id={PUBLIC_PFB_ANALYTICS_ID}
+  ></script>
 </svelte:head>
 
 <div class="min-h-screen flex flex-col">

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -18,7 +18,7 @@ const config = {
     csp: {
       mode: 'auto',
       directives: {
-        'script-src': ['self']
+        'script-src': ['self', 'https://analytics.polyflowbuilder.io']
       }
     }
   }


### PR DESCRIPTION
This PR adds an analytics endpoint to PolyFlowBuilder using Umami (https://umami.is/), a privacy-focused lightweight analytics solution. This will be to monitor aggregated traffic and to see what types of devices are being used to access the website. No personally identifiable information (eg IPs) are included in the analytics and no cookies are used.

No tests are needed for this functionality.