### PR TITLE
Update unit counting logic for computing group units

### DIFF
--- a/src/lib/client/util/unitCounterUtilClient.test.ts
+++ b/src/lib/client/util/unitCounterUtilClient.test.ts
@@ -31,7 +31,7 @@ describe('computeGroupUnits tests', () => {
       conc2: '0',
       ge: '44',
       elective: '3-4',
-      other: '0',
+      other: '13',
       total: '500'
     };
 

--- a/src/lib/client/util/unitCounterUtilClient.ts
+++ b/src/lib/client/util/unitCounterUtilClient.ts
@@ -50,7 +50,9 @@ export function computeGroupUnits(
         .find((cache) => cache.catalog === courseCatalog)
         ?.courses.find((c) => c.id === course.id);
 
-      const units = course.customId ? course.customUnits : courseMetadata?.units;
+      // customUnits takes precedence even if we have a standard course
+      // (for standard+customUnit cases)
+      const units = course.customUnits ?? courseMetadata?.units;
 
       if (units) {
         if (COLORS.major.includes(course.color)) {

--- a/src/lib/common/util/unitCounterUtilCommon.test.ts
+++ b/src/lib/common/util/unitCounterUtilCommon.test.ts
@@ -345,7 +345,7 @@ describe('computeTotalUnits tests', () => {
       (crsData) => crsData.catalog === '2021-2022'
     );
     expect(computeTotalUnits(flowTermData, courseCache, apiDataConfig.apiData.programData)).toBe(
-      '183-185'
+      '196-198'
     );
   });
 
@@ -368,6 +368,6 @@ describe('computeTotalUnits tests', () => {
       computeTotalUnits(flowTermData, courseCache, apiDataConfig.apiData.programData, true, [
         'fd2f33be-3103-4b3d-a17b-94ced0d7998f'
       ])
-    ).toBe('179-181');
+    ).toBe('192-194');
   });
 });

--- a/tests/util/testFlowcharts.ts
+++ b/tests/util/testFlowcharts.ts
@@ -68,7 +68,7 @@ export const TEST_FLOWCHART_SINGLE_PROGRAM_1: Flowchart = {
     },
     {
       tIndex: 3,
-      tUnits: '16',
+      tUnits: '24',
       courses: [
         {
           color: '#FEFD9A',
@@ -89,6 +89,11 @@ export const TEST_FLOWCHART_SINGLE_PROGRAM_1: Flowchart = {
         {
           color: '#DCFDD2',
           id: 'COMS126'
+        },
+        {
+          id: 'CPE101',
+          color: '#FFFFFF',
+          customUnits: '8'
         }
       ]
     },
@@ -218,7 +223,7 @@ export const TEST_FLOWCHART_SINGLE_PROGRAM_1: Flowchart = {
     },
     {
       tIndex: 10,
-      tUnits: '16',
+      tUnits: '21',
       courses: [
         {
           color: '#FEFD9A',
@@ -231,6 +236,11 @@ export const TEST_FLOWCHART_SINGLE_PROGRAM_1: Flowchart = {
         {
           color: '#FEFD9A',
           id: 'JOUR312'
+        },
+        {
+          color: '#FFFFFF',
+          id: 'CPE100',
+          customUnits: '5'
         },
         {
           color: '#DCFDD2',


### PR DESCRIPTION
This PR updates the unit counting logic for computing group units (the units in the footer of the editor). This should have been included in #46 but it slipped my mind. The logic has been updated to prioritize if a course has a `customUnits` field, as this field may be present even if we don't have a custom course (for `standard+customUnits` courses). Now, the unit counts in the flowchart editor and in the footer should be aligned.

Tests were updated to exercise this new logic.

This is the last piece to fix issue #45.