### PR TITLE
Change Actions <button> to <label> to avoid Safari bug

### DIFF
--- a/src/lib/components/Flows/FlowInfoPanel/FlowInfoPanelActionsDropdown.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/FlowInfoPanelActionsDropdown.svelte
@@ -4,8 +4,8 @@
   import { faSortDown } from '@fortawesome/free-solid-svg-icons';
   import { userFlowcharts } from '$lib/client/stores/userDataStore';
   import {
-    FlowInfoPanelActionsColorSelector,
-    FlowInfoPanelActionsGeneratePDF
+    FlowInfoPanelActionsGeneratePDF,
+    FlowInfoPanelActionsColorSelector
   } from '$lib/components/Flows/FlowInfoPanel';
   import {
     duplicateFlowchart,
@@ -13,10 +13,10 @@
     deleteSelectedCourses
   } from '$lib/client/util/flowActionsUtil';
   import {
+    selectedColor,
     selectedCourses,
     viewingCreditBin,
-    selectedFlowIndex,
-    selectedColor
+    selectedFlowIndex
   } from '$lib/client/stores/UIDataStore';
   import {
     addTermsModalOpen,
@@ -29,16 +29,20 @@
 </script>
 
 <div class="dropdown">
-  <button
+  <!-- svelte-ignore a11y-no-noninteractive-element-to-interactive-role -->
+  <!-- svelte-ignore a11y-label-has-associated-control -->
+  <label
     tabindex="0"
+    role="button"
     class="flex-1 gap-0 btn btn-almostmd border-none text-white bg-gray-400 hover:bg-gray-500"
-    disabled={actionsButtonDisabled}
+    class:btn-disabled={actionsButtonDisabled}
+    aria-disabled={actionsButtonDisabled}
   >
     Actions
     <span class="ml-1 mb-1">
       <Fa icon={faSortDown} />
     </span>
-  </button>
+  </label>
 
   <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
   <ul


### PR DESCRIPTION
closes #56.

This PR is to change the Actions <button> tag to a <label> tag to avoid a Safari bug that prevents Safari users from opening the Actions menu. Reference:

https://daisyui.com/components/dropdown/
https://bugs.webkit.org/show_bug.cgi?id=22261

The fix was tested manually and all existing tests passed. This PR is impacted by #57, so regression tests cannot be added to ensure this functionality is working properly for Safari users.

Since this is an important bug to fix, we will ship this but this needs to be looked into further.