### PR TITLE
Update `homeCarouselTestUtil` to pass in WebKit

### DIFF
--- a/tests/util/homeCarouselTestUtil.ts
+++ b/tests/util/homeCarouselTestUtil.ts
@@ -14,8 +14,8 @@ export async function checkCarouselSlide(page: Page, slideIndex: number) {
   expect(await slideImage.getAttribute('alt')).toBe(homeCarouselImageData[slideIndex].title);
 
   // check text descriptions
-  expect(await slideImageContainer.innerText()).toBe(
-    `${homeCarouselImageData[slideIndex].title}\n\n${homeCarouselImageData[slideIndex].desc}`
+  expect(await slideImageContainer.textContent()).toBe(
+    ` ${homeCarouselImageData[slideIndex].title} ${homeCarouselImageData[slideIndex].desc} `
   );
 
   // ensure visible


### PR DESCRIPTION
This PR is a simple change to update `homeCarouselTestUtil` to allow the `homePageTests` to pass in the Playwright WebKit environment (see #55).

Existing tests all pass with this change.