### PR TITLE
 Course search UX improvements

### DIFF
--- a/src/lib/client/config/catalogSearchConfigClient.ts
+++ b/src/lib/client/config/catalogSearchConfigClient.ts
@@ -33,3 +33,18 @@ export const fieldSelectorTooltipConfig: Partial<Props> = {
     '</div>',
   hideOnClick: false
 };
+
+export const searchHelpTooltipConfig: Partial<Props> = {
+  arrow: false,
+  placement: 'bottom',
+  theme: 'light-border',
+  allowHTML: true,
+  content:
+    '<div class="whitespace-pre-wrap">' +
+    'If you cannot find the courses you are looking for, here are some course searching tips:' +
+    '\n\n1. Make sure your query is spelled correctly. The search tool does not support misspelled queries.' +
+    '\n\n2. If you are searching on Course ID, ensure that there are no spaces in between the letters and numbers of the ID.' +
+    "\n\n3. Verify that the course you are trying to add is in the selected Program's catalog. Only courses from this catalog are displayed in search results." +
+    '</div>',
+  hideOnClick: false
+};

--- a/src/lib/client/config/catalogSearchConfigClient.ts
+++ b/src/lib/client/config/catalogSearchConfigClient.ts
@@ -42,7 +42,7 @@ export const searchHelpTooltipConfig: Partial<Props> = {
   content:
     '<div style="white-space: pre-wrap;">' +
     'If you cannot find the courses you are looking for, here are some course searching tips:' +
-    '\n\n1. Make sure your query is spelled correctly. The search tool does not support misspelled queries.' +
+    '\n\n1. Make sure your query is spelled correctly (searches are not case sensitive). The search tool does not support misspelled queries.' +
     '\n\n2. If you are searching on Course ID, ensure that there are no spaces in between the letters and numbers of the ID.' +
     "\n\n3. Verify that the course you are trying to add is in the selected Program's catalog. Only courses from this catalog are displayed in search results." +
     '</div>',

--- a/src/lib/client/config/catalogSearchConfigClient.ts
+++ b/src/lib/client/config/catalogSearchConfigClient.ts
@@ -11,9 +11,10 @@ export const programSelectorTooltipConfig: Partial<Props> = {
   arrow: false,
   placement: 'right-start',
   theme: 'light-border',
+  allowHTML: true,
   content:
     'Which program to associate the searched courses with. ' +
-    "The search is restricted to the selected program's catalog.",
+    "<u>The search is restricted to the selected program's catalog.</u>",
   hideOnClick: false
 };
 
@@ -23,10 +24,12 @@ export const fieldSelectorTooltipConfig: Partial<Props> = {
   theme: 'light-border',
   allowHTML: true,
   content:
-    '<div class="whitespace-pre-wrap">Which part of the course to search on.' +
+    '<div class="whitespace-pre-wrap">' +
+    'Which part of the course to search on.' +
     '\n\n<strong>Course ID: </strong>The ID of the course (e.g. "CPE101"). ' +
-    'Note that there is no space in the course ID.' +
+    'Note that <u>there is no space</u> in the course ID.' +
     '\n\n<strong>Course Name: </strong>The name of the course' +
-    '\n(e.g. "Fundamentals of Computer Science").',
+    '\n(e.g. "Fundamentals of Computer Science").' +
+    '</div>',
   hideOnClick: false
 };

--- a/src/lib/client/config/catalogSearchConfigClient.ts
+++ b/src/lib/client/config/catalogSearchConfigClient.ts
@@ -24,7 +24,7 @@ export const fieldSelectorTooltipConfig: Partial<Props> = {
   theme: 'light-border',
   allowHTML: true,
   content:
-    '<div class="whitespace-pre-wrap">' +
+    '<div style="white-space: pre-wrap;">' +
     'Which part of the course to search on.' +
     '\n\n<strong>Course ID: </strong>The ID of the course (e.g. "CPE101"). ' +
     'Note that <u>there is no space</u> in the course ID.' +
@@ -40,7 +40,7 @@ export const searchHelpTooltipConfig: Partial<Props> = {
   theme: 'light-border',
   allowHTML: true,
   content:
-    '<div class="whitespace-pre-wrap">' +
+    '<div style="white-space: pre-wrap;">' +
     'If you cannot find the courses you are looking for, here are some course searching tips:' +
     '\n\n1. Make sure your query is spelled correctly. The search tool does not support misspelled queries.' +
     '\n\n2. If you are searching on Course ID, ensure that there are no spaces in between the letters and numbers of the ID.' +

--- a/src/lib/client/config/catalogSearchConfigClient.ts
+++ b/src/lib/client/config/catalogSearchConfigClient.ts
@@ -1,0 +1,5 @@
+// client-side catalog search config
+export const SEARCH_DELAY_TIME_MS = 500;
+
+// client-side catalog search constants
+export const BOOLEAN_SEARCH_OPERATORS_REGEX = new RegExp(/[@+\-><()~*"]/);

--- a/src/lib/client/config/catalogSearchConfigClient.ts
+++ b/src/lib/client/config/catalogSearchConfigClient.ts
@@ -1,5 +1,32 @@
+import type { Props } from 'tippy.js';
+
 // client-side catalog search config
 export const SEARCH_DELAY_TIME_MS = 500;
 
 // client-side catalog search constants
 export const BOOLEAN_SEARCH_OPERATORS_REGEX = new RegExp(/[@+\-><()~*"]/);
+
+// search tooltip configs
+export const programSelectorTooltipConfig: Partial<Props> = {
+  arrow: false,
+  placement: 'right-start',
+  theme: 'light-border',
+  content:
+    'Which program to associate the searched courses with. ' +
+    "The search is restricted to the selected program's catalog.",
+  hideOnClick: false
+};
+
+export const fieldSelectorTooltipConfig: Partial<Props> = {
+  arrow: false,
+  placement: 'right-start',
+  theme: 'light-border',
+  allowHTML: true,
+  content:
+    '<div class="whitespace-pre-wrap">Which part of the course to search on.' +
+    '\n\n<strong>Course ID: </strong>The ID of the course (e.g. "CPE101"). ' +
+    'Note that there is no space in the course ID.' +
+    '\n\n<strong>Course Name: </strong>The name of the course' +
+    '\n(e.g. "Fundamentals of Computer Science").',
+  hideOnClick: false
+};

--- a/src/lib/client/util/courseItemUtil.ts
+++ b/src/lib/client/util/courseItemUtil.ts
@@ -53,7 +53,7 @@ export function buildTermCourseItemsData(
       itemData.tooltipParams = {
         arrow: false,
         placement: 'right-start',
-        theme: 'light',
+        theme: 'light-border',
         allowHTML: true,
         content: generateCourseItemTooltipHTML(computedCourseDisplayValues),
         maxWidth: MAX_TOOLTIP_WIDTH_PX,

--- a/src/lib/client/util/courseSearchUtil.ts
+++ b/src/lib/client/util/courseSearchUtil.ts
@@ -1,6 +1,9 @@
 import { courseCache } from '$lib/client/stores/apiDataStore';
-import { SEARCH_DELAY_TIME_MS } from '$lib/common/config/catalogSearchConfig';
 import { activeSearchResults, searchCache } from '$lib/client/stores/catalogSearchStore';
+import {
+  SEARCH_DELAY_TIME_MS,
+  BOOLEAN_SEARCH_OPERATORS_REGEX
+} from '$lib/common/config/catalogSearchConfig';
 import type { CatalogSearchValidFields } from '$lib/server/schema/searchCatalogSchema';
 import type { CatalogSearchResults, CourseCache, SearchCache } from '$lib/types';
 
@@ -10,6 +13,13 @@ let fullSearchCache: SearchCache[] = [];
 let fullCourseCache: CourseCache[] = [];
 searchCache.subscribe((cache) => (fullSearchCache = cache));
 courseCache.subscribe((cache) => (fullCourseCache = cache));
+
+// if any boolean operators are present, return the query as-is
+// else, add a wildcard at the end, as users expect the search tool
+//  to function in this manner
+export function transformRawQuery(query: string): string {
+  return !query.length || BOOLEAN_SEARCH_OPERATORS_REGEX.test(query) ? query : `${query}*`;
+}
 
 export function initSearch(query: string, catalog: string, field: CatalogSearchValidFields) {
   if (!delayingBeforeSearch) {

--- a/src/lib/client/util/courseSearchUtil.ts
+++ b/src/lib/client/util/courseSearchUtil.ts
@@ -3,7 +3,7 @@ import { activeSearchResults, searchCache } from '$lib/client/stores/catalogSear
 import {
   SEARCH_DELAY_TIME_MS,
   BOOLEAN_SEARCH_OPERATORS_REGEX
-} from '$lib/common/config/catalogSearchConfig';
+} from '$lib/client/config/catalogSearchConfigClient';
 import type { CatalogSearchValidFields } from '$lib/server/schema/searchCatalogSchema';
 import type { CatalogSearchResults, CourseCache, SearchCache } from '$lib/types';
 

--- a/src/lib/common/config/catalogSearchConfig.ts
+++ b/src/lib/common/config/catalogSearchConfig.ts
@@ -1,8 +1,5 @@
 // catalog search parameters
-export const SEARCH_DELAY_TIME_MS = 500;
 export const MAX_SEARCH_RESULTS_RETURN_COUNT = 24;
-
-export const BOOLEAN_SEARCH_OPERATORS_REGEX = new RegExp(/[@+\-><()~*"]/);
 
 // TODO: doesn't belong here
 export const SANITIZE_REGEX = (input: string): string =>

--- a/src/lib/common/config/catalogSearchConfig.ts
+++ b/src/lib/common/config/catalogSearchConfig.ts
@@ -2,6 +2,8 @@
 export const SEARCH_DELAY_TIME_MS = 500;
 export const MAX_SEARCH_RESULTS_RETURN_COUNT = 24;
 
+export const BOOLEAN_SEARCH_OPERATORS_REGEX = new RegExp(/[@+\-><()~*"]/);
+
 // TODO: doesn't belong here
 export const SANITIZE_REGEX = (input: string): string =>
   input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
@@ -3,13 +3,13 @@
   import CourseItem from '../../FlowEditor/CourseItem.svelte';
   import MutableForEachContainer from '$lib/components/common/MutableForEachContainer.svelte';
   import CourseSearchOptionsSelector from './CourseSearchOptionsSelector.svelte';
-  import { initSearch } from '$lib/client/util/courseSearchUtil';
   import { userFlowcharts } from '$lib/client/stores/userDataStore';
   import { selectedFlowIndex } from '$lib/client/stores/UIDataStore';
   import { COURSE_ITEM_SIZE_PX } from '$lib/client/config/uiConfig';
   import { buildTermCourseItemsData } from '$lib/client/util/courseItemUtil';
   import { courseCache, programCache } from '$lib/client/stores/apiDataStore';
   import { getCatalogFromProgramIDIndex } from '$lib/common/util/courseDataUtilCommon';
+  import { initSearch, transformRawQuery } from '$lib/client/util/courseSearchUtil';
   import { MAX_SEARCH_RESULTS_RETURN_COUNT } from '$lib/common/config/catalogSearchConfig';
   import { activeSearchResults, searchCache } from '$lib/client/stores/catalogSearchStore';
   import { faExclamationCircle, faFileCircleXmark } from '@fortawesome/free-solid-svg-icons';
@@ -28,6 +28,9 @@
   // for optional type
   $: selectedFlow = $userFlowcharts[$selectedFlowIndex] as Flowchart | undefined;
 
+  // query transformation
+  $: transformedQuery = transformRawQuery(query);
+
   // reset searches when we switch flows
   $: {
     $selectedFlowIndex;
@@ -45,7 +48,7 @@
     if (selectedCatalog) {
       // reset results in UI so we don't see stale results during new query
       $activeSearchResults = undefined;
-      initSearch(query, selectedCatalog, field);
+      initSearch(transformedQuery, selectedCatalog, field);
     }
   }
 
@@ -97,7 +100,7 @@
     {:then results}
       {#if results && searchProgramIndex !== -1 && $searchCache
           .find((entry) => entry.catalog === selectedCatalog)
-          ?.searches.find((searchRecord) => searchRecord.query === `${field}|${query}`)}
+          ?.searches.find((searchRecord) => searchRecord.query === `${field}|${transformedQuery}`)}
         {#if !results.searchValid}
           <div class="text-center">
             <div class="invalidSearchIcon pb-2">

--- a/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
@@ -3,9 +3,11 @@
   import CourseItem from '../../FlowEditor/CourseItem.svelte';
   import MutableForEachContainer from '$lib/components/common/MutableForEachContainer.svelte';
   import CourseSearchOptionsSelector from './CourseSearchOptionsSelector.svelte';
+  import { tooltip } from '$lib/client/util/tooltipUtil';
   import { userFlowcharts } from '$lib/client/stores/userDataStore';
   import { selectedFlowIndex } from '$lib/client/stores/UIDataStore';
   import { COURSE_ITEM_SIZE_PX } from '$lib/client/config/uiConfig';
+  import { searchHelpTooltipConfig } from '$lib/client/config/catalogSearchConfigClient';
   import { buildTermCourseItemsData } from '$lib/client/util/courseItemUtil';
   import { courseCache, programCache } from '$lib/client/stores/apiDataStore';
   import { getCatalogFromProgramIDIndex } from '$lib/common/util/courseDataUtilCommon';
@@ -118,6 +120,9 @@
             <small class="text-gray-500"
               >No results found. Please verify that the search parameters are correct.
             </small>
+            <small use:tooltip={searchHelpTooltipConfig} class="hyperlink cursor-pointer"
+              >Need help?</small
+            >
           </div>
         {:else}
           <!-- TODO: the text in the slot should always stay at the bottom of the results section -->
@@ -140,6 +145,9 @@
                 <small class="text-gray-500"
                   >If you could not find a particular course, verify and/or narrow your search
                   parameters.</small
+                >
+                <small use:tooltip={searchHelpTooltipConfig} class="hyperlink cursor-pointer"
+                  >Need help?</small
                 >
               {/if}
             </div>

--- a/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
@@ -112,7 +112,9 @@
             <div class="noResultsIcon pb-2">
               <Fa icon={faFileCircleXmark} style="margin: auto;" />
             </div>
-            <small class="text-gray-500">No results found. Please try a different search.</small>
+            <small class="text-gray-500"
+              >No results found. Please verify that the search parameters are correct.
+            </small>
           </div>
         {:else}
           <!-- TODO: the text in the slot should always stay at the bottom of the results section -->
@@ -133,8 +135,8 @@
               {/if}
               {#if results.searchValid}
                 <small class="text-gray-500"
-                  >If you could not find a particular course, verify and narrow your search options
-                  if applicable.</small
+                  >If you could not find a particular course, verify and/or narrow your search
+                  parameters.</small
                 >
               {/if}
             </div>

--- a/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
@@ -20,7 +20,7 @@
   // search options
   let searchProgramIndex = -1;
   let query = '';
-  let field: CatalogSearchValidFields = 'displayName';
+  let field: CatalogSearchValidFields = 'id';
 
   // search results
   let items: CourseItemData[] = [];
@@ -32,7 +32,7 @@
   $: {
     $selectedFlowIndex;
     searchProgramIndex = $selectedFlowIndex !== -1 ? 0 : -1;
-    field = 'displayName';
+    field = 'id';
     query = '';
   }
 

--- a/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/CourseSearchOptionsSelector.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/CourseSearchOptionsSelector.svelte
@@ -4,6 +4,10 @@
   import { userFlowcharts } from '$lib/client/stores/userDataStore';
   import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
   import { flowListUIData, selectedFlowIndex } from '$lib/client/stores/UIDataStore';
+  import {
+    fieldSelectorTooltipConfig,
+    programSelectorTooltipConfig
+  } from '$lib/client/config/catalogSearchConfigClient';
 
   export let searchProgramIndex = -1;
   export let query = '';
@@ -38,14 +42,7 @@
       </select>
     </label>
     <div
-      use:tooltip={{
-        arrow: false,
-        placement: 'right-start',
-        theme: 'light-border',
-        content:
-          "Which program to associate the searched courses with. The search is restricted to the selected program's catalog.",
-        hideOnClick: false
-      }}
+      use:tooltip={programSelectorTooltipConfig}
       class="ml-1 mt-1 text-blue-500 hover:text-blue-600 transition cursor-pointer"
     >
       <Fa icon={faQuestionCircle} />
@@ -67,15 +64,7 @@
       </select>
     </label>
     <div
-      use:tooltip={{
-        arrow: false,
-        placement: 'right-start',
-        theme: 'light-border',
-        allowHTML: true,
-        content:
-          '<div class="whitespace-pre-wrap">Which part of the course to search on.\n\n<strong>Course ID: </strong>The ID of the course (e.g. "CPE101"). Note that there is no space in the course ID.\n\n<strong>Course Name: </strong>The name of the course\n(e.g. "Fundamentals of Computer Science").',
-        hideOnClick: false
-      }}
+      use:tooltip={fieldSelectorTooltipConfig}
       class="ml-1 mt-1 text-blue-500 hover:text-blue-600 transition cursor-pointer"
     >
       <Fa icon={faQuestionCircle} />

--- a/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/CourseSearchOptionsSelector.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/CourseSearchOptionsSelector.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Fa from 'svelte-fa';
+  import { tooltip } from '$lib/client/util/tooltipUtil';
   import { userFlowcharts } from '$lib/client/stores/userDataStore';
   import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
   import { flowListUIData, selectedFlowIndex } from '$lib/client/stores/UIDataStore';
@@ -36,7 +37,17 @@
         {/each}
       </select>
     </label>
-    <div class="ml-1 mt-1 text-blue-500">
+    <div
+      use:tooltip={{
+        arrow: false,
+        placement: 'right-start',
+        theme: 'light-border',
+        content:
+          "Which program to associate the searched courses with. The search is restricted to the selected program's catalog.",
+        hideOnClick: false
+      }}
+      class="ml-1 mt-1 text-blue-500 hover:text-blue-600 transition cursor-pointer"
+    >
       <Fa icon={faQuestionCircle} />
     </div>
   </div>
@@ -55,7 +66,18 @@
         <option value="id">Course ID</option>
       </select>
     </label>
-    <div class="ml-1 mt-1 text-blue-500">
+    <div
+      use:tooltip={{
+        arrow: false,
+        placement: 'right-start',
+        theme: 'light-border',
+        allowHTML: true,
+        content:
+          '<div class="whitespace-pre-wrap">Which part of the course to search on.\n\n<strong>Course ID: </strong>The ID of the course (e.g. "CPE101"). Note that there is no space in the course ID.\n\n<strong>Course Name: </strong>The name of the course\n(e.g. "Fundamentals of Computer Science").',
+        hideOnClick: false
+      }}
+      class="ml-1 mt-1 text-blue-500 hover:text-blue-600 transition cursor-pointer"
+    >
       <Fa icon={faQuestionCircle} />
     </div>
   </div>

--- a/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/CourseSearchOptionsSelector.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/CourseSearchOptionsSelector.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import Fa from 'svelte-fa';
   import { userFlowcharts } from '$lib/client/stores/userDataStore';
+  import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
   import { flowListUIData, selectedFlowIndex } from '$lib/client/stores/UIDataStore';
 
   export let searchProgramIndex = -1;
@@ -16,37 +18,47 @@
 
 <div>
   <!-- program selector -->
-  <label class="join group-input group-input-sm">
-    <span class="join-item">Program: </span>
-    <select
-      class="select join-item select-bordered select-sm overflow-ellipsis flowProgramSelector"
-      aria-label="course search program selector"
-      disabled={$selectedFlowIndex === -1}
-      bind:value={searchProgramIndex}
-    >
-      {#if $selectedFlowIndex === -1}
-        <option disabled value={-1}>Select a Flowchart</option>
-      {/if}
+  <div class="flex">
+    <label class="join group-input group-input-xs">
+      <span class="join-item">Program: </span>
+      <select
+        class="select join-item select-bordered select-xs overflow-ellipsis flowProgramSelector"
+        aria-label="course search program selector"
+        disabled={$selectedFlowIndex === -1}
+        bind:value={searchProgramIndex}
+      >
+        {#if $selectedFlowIndex === -1}
+          <option disabled value={-1}>Select a Flowchart</option>
+        {/if}
 
-      {#each $userFlowcharts[$selectedFlowIndex]?.programId ?? [] as _, i}
-        <option value={i}>{createSearchFlowProgramSelectorFriendlyName(i)}</option>
-      {/each}
-    </select>
-  </label>
+        {#each $userFlowcharts[$selectedFlowIndex]?.programId ?? [] as _, i}
+          <option value={i}>{createSearchFlowProgramSelectorFriendlyName(i)}</option>
+        {/each}
+      </select>
+    </label>
+    <div class="ml-1 mt-1 text-blue-500">
+      <Fa icon={faQuestionCircle} />
+    </div>
+  </div>
 
   <!-- field selector -->
-  <label class="mt-2 join group-input group-input-sm">
-    <span class="join-item">Search On:</span>
-    <select
-      class="select join-item select-bordered select-sm overflow-ellipsis searchFieldSelector"
-      aria-label="course search field selector"
-      disabled={$selectedFlowIndex === -1}
-      bind:value={field}
-    >
-      <option value="displayName">Course Name</option>
-      <option value="id">Course ID</option>
-    </select>
-  </label>
+  <div class="mt-2 flex">
+    <label class="join group-input group-input-xs">
+      <span class="join-item">Search On:</span>
+      <select
+        class="select join-item select-bordered select-xs overflow-ellipsis searchFieldSelector"
+        aria-label="course search field selector"
+        disabled={$selectedFlowIndex === -1}
+        bind:value={field}
+      >
+        <option value="displayName">Course Name</option>
+        <option value="id">Course ID</option>
+      </select>
+    </label>
+    <div class="ml-1 mt-1 text-blue-500">
+      <Fa icon={faQuestionCircle} />
+    </div>
+  </div>
 
   <!-- query input -->
   <input
@@ -60,17 +72,16 @@
 </div>
 
 <style lang="postcss">
-  /* 91px is the width of the gray pill on the left */
+  /* pixel counts are the width of the gray pill on the left */
   .flowProgramSelector {
-    width: calc(100% - 91px);
+    width: calc(100% - 83px);
   }
-  /* 104px is the width of the gray pill on the left */
   .searchFieldSelector {
-    width: calc(100% - 104px);
+    width: calc(100% - 93px);
   }
 
-  .group-input-sm {
-    font-size: 0.875rem; /* 14px */
-    line-height: 2rem; /* 32px */
+  .group-input-xs {
+    font-size: 0.75rem; /* 12px */
+    line-height: 1rem; /* 16px */
   }
 </style>

--- a/tests/page/flows/search/courseSearchOptionsSelectorTests.test.ts
+++ b/tests/page/flows/search/courseSearchOptionsSelectorTests.test.ts
@@ -91,7 +91,7 @@ test.describe('CourseSearchOptionsSelector tests', () => {
     await expect(courseSearchFieldSelector).toBeVisible();
     await expect(courseSearchFieldSelector).toBeInViewport();
     await expect(courseSearchFieldSelector).toBeDisabled();
-    await expect(courseSearchFieldSelector).toHaveValue('displayName');
+    await expect(courseSearchFieldSelector).toHaveValue('id');
 
     // expect default state of query box
     const courseSearchQueryBox = page.getByRole('searchbox', {
@@ -150,7 +150,7 @@ test.describe('CourseSearchOptionsSelector tests', () => {
     await expect(courseSearchFieldSelector).toBeVisible();
     await expect(courseSearchFieldSelector).toBeInViewport();
     await expect(courseSearchFieldSelector).toBeEnabled();
-    await expect(courseSearchFieldSelector).toHaveValue('displayName');
+    await expect(courseSearchFieldSelector).toHaveValue('id');
 
     const courseSearchQueryBox = page.getByRole('searchbox', {
       name: 'course search query input'
@@ -211,7 +211,7 @@ test.describe('CourseSearchOptionsSelector tests', () => {
     await expect(courseSearchFieldSelector).toBeVisible();
     await expect(courseSearchFieldSelector).toBeInViewport();
     await expect(courseSearchFieldSelector).toBeEnabled();
-    await expect(courseSearchFieldSelector).toHaveValue('displayName');
+    await expect(courseSearchFieldSelector).toHaveValue('id');
 
     const courseSearchQueryBox = page.getByRole('searchbox', {
       name: 'course search query input'
@@ -296,7 +296,7 @@ test.describe('CourseSearchOptionsSelector tests', () => {
       page.getByRole('combobox', {
         name: 'course search field selector'
       })
-    ).toHaveValue('displayName');
+    ).toHaveValue('id');
 
     await expect(
       page.getByRole('searchbox', {

--- a/tests/page/flows/search/courseSearchTests.test.ts
+++ b/tests/page/flows/search/courseSearchTests.test.ts
@@ -345,7 +345,7 @@ test.describe('course search tests', () => {
       .getByRole('searchbox', {
         name: 'course search query input'
       })
-      .fill('beekeeping');
+      .fill('plsc175');
     await expect(page.locator('.flowInfoPanel .loading-spinner')).toHaveCount(1);
     const response = await responsePromise;
 
@@ -461,7 +461,7 @@ test.describe('course search tests', () => {
       .getByRole('searchbox', {
         name: 'course search query input'
       })
-      .fill('beekeeping');
+      .fill('PlSc175');
     await expect(page.locator('.flowInfoPanel .loading-spinner')).toHaveCount(1);
     const response = await responsePromise;
 


### PR DESCRIPTION
closes #53.

This PR is a collection of UX improvements to the Course Search tool. The current improvements are:

1. include blue help bubbles next to the search option dropdowns that give instructions on what each option does.
2. set the default "Search On" parameter to "course ID" as most people expect this versus having it set to "course name" (according to user anecdotes/feedback)
3. all queries that do not include any boolean operators (see https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html) will now automatically have a wildcard appended to it (so "cpe" will now query "cpe*"). This allows users to start typing characters of a query and having results populate, instead of the tool reporting No Results until a full term is typed exactly correctly (e.g. "cpe101").