### PR TITLE
feat: reorganize some API endpoints

### DIFF
--- a/src/lib/client/util/courseSearchUtil.ts
+++ b/src/lib/client/util/courseSearchUtil.ts
@@ -82,7 +82,7 @@ async function performSearch(
     query,
     field
   });
-  const searchResults = (await fetch(`/api/data/searchCatalog?${searchParams.toString()}`)
+  const searchResults = (await fetch(`/api/data/queryCourseCatalog?${searchParams.toString()}`)
     .then((resp) => {
       if (resp.status === 400) {
         return {

--- a/src/lib/components/Flows/FlowInfoPanel/FlowInfoPanelActionsGeneratePDF.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/FlowInfoPanelActionsGeneratePDF.svelte
@@ -11,7 +11,7 @@
     const searchParams = new URLSearchParams({
       flowchartId: $userFlowcharts[$selectedFlowIndex]?.id
     });
-    await fetch(`/api/data/generatePDF?${searchParams.toString()}`)
+    await fetch(`/api/util/generateFlowchartPDF?${searchParams.toString()}`)
       .then(async (resp) => {
         switch (resp.status) {
           case 200: {

--- a/src/lib/components/Flows/modals/NewFlowModal.svelte
+++ b/src/lib/components/Flows/modals/NewFlowModal.svelte
@@ -46,7 +46,7 @@
     };
     const searchParams = new URLSearchParams(payload);
 
-    const resp = await fetch(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const resp = await fetch(`/api/util/generateFlowchart?${searchParams.toString()}`);
     switch (resp.status) {
       case 200: {
         const respJson = (await resp.json()) as {

--- a/src/routes/api/data/queryCourseCatalog/+server.ts
+++ b/src/routes/api/data/queryCourseCatalog/+server.ts
@@ -5,7 +5,7 @@ import { searchCatalog } from '$lib/server/db/course';
 import { searchCatalogSchema } from '$lib/server/schema/searchCatalogSchema';
 import type { RequestHandler } from '@sveltejs/kit';
 
-const logger = initLogger('APIRouteHandler (/api/data/searchCatalog)');
+const logger = initLogger('APIRouteHandler (/api/data/queryCourseCatalog)');
 
 export const GET: RequestHandler = async ({ locals, url }) => {
   try {

--- a/src/routes/api/util/generateFlowchart/+server.ts
+++ b/src/routes/api/util/generateFlowchart/+server.ts
@@ -6,7 +6,7 @@ import { getProgramsFromIds } from '$lib/server/db/program';
 import { generateFlowchartSchema } from '$lib/server/schema/generateFlowchartSchema';
 import type { RequestHandler } from '@sveltejs/kit';
 
-const logger = initLogger('APIRouteHandler (/api/data/generateFlowchart)');
+const logger = initLogger('APIRouteHandler (/api/util/generateFlowchart)');
 
 export const GET: RequestHandler = async ({ locals, url }) => {
   try {

--- a/src/routes/api/util/generateFlowchartPDF/+server.ts
+++ b/src/routes/api/util/generateFlowchartPDF/+server.ts
@@ -6,7 +6,7 @@ import { generateCourseCacheFlowcharts } from '$lib/server/util/courseCacheUtil'
 import { extractPDFDataFromFlowchart, generatePDF } from '$lib/server/util/generatePDF';
 import type { RequestHandler } from '@sveltejs/kit';
 
-const logger = initLogger('APIRouteHandler (/api/data/generatePDF)');
+const logger = initLogger('APIRouteHandler (/api/util/generateFlowchartPDF)');
 
 export const GET: RequestHandler = async ({ locals, url }) => {
   try {

--- a/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
+++ b/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
@@ -43,7 +43,7 @@ test.describe('generate flowchart api input tests', () => {
   });
 
   test('generate flowchart api returns 401 without authorization', async ({ request }) => {
-    const res = await request.get('/api/data/generateFlowchart');
+    const res = await request.get('/api/util/generateFlowchart');
 
     const expectedResponseBody = {
       message: 'Generate flowchart request must be authenticated.'
@@ -56,7 +56,7 @@ test.describe('generate flowchart api input tests', () => {
   test('generate flowchart api returns 400 without any data', async ({ request }) => {
     await performLoginBackend(request, userEmail, 'test');
 
-    const res = await request.get('/api/data/generateFlowchart');
+    const res = await request.get('/api/util/generateFlowchart');
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -79,7 +79,7 @@ test.describe('generate flowchart api input tests', () => {
       programIds: '68be11b7-389b-4ebc-9b95-8997e7314497'
     });
 
-    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const res = await request.get(`/api/util/generateFlowchart?${searchParams.toString()}`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -101,7 +101,7 @@ test.describe('generate flowchart api input tests', () => {
       programIds: '68be11b7-389b-4ebc-9b95-8997e7314497'
     });
 
-    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const res = await request.get(`/api/util/generateFlowchart?${searchParams.toString()}`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -128,7 +128,7 @@ test.describe('generate flowchart api input tests', () => {
       programIds: '68be11b7-389b-4ebc-9b95-8997e7314497'
     });
 
-    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const res = await request.get(`/api/util/generateFlowchart?${searchParams.toString()}`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -150,7 +150,7 @@ test.describe('generate flowchart api input tests', () => {
       programIds: '68be11b7-389b-4ebc-9b95-8997e7314497'
     });
 
-    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const res = await request.get(`/api/util/generateFlowchart?${searchParams.toString()}`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -172,7 +172,7 @@ test.describe('generate flowchart api input tests', () => {
       programIds: '68be11b7-389b-4ebc-9b95-8997e7314497'
     });
 
-    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const res = await request.get(`/api/util/generateFlowchart?${searchParams.toString()}`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -196,7 +196,7 @@ test.describe('generate flowchart api input tests', () => {
       programIds: 'invalid'
     });
 
-    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const res = await request.get(`/api/util/generateFlowchart?${searchParams.toString()}`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -220,7 +220,7 @@ test.describe('generate flowchart api input tests', () => {
       programIds: '68be11b7-389b-4ebc-9b95-8997e7314497,invalid'
     });
 
-    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const res = await request.get(`/api/util/generateFlowchart?${searchParams.toString()}`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -242,7 +242,7 @@ test.describe('generate flowchart api input tests', () => {
       programIds: ''
     });
 
-    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const res = await request.get(`/api/util/generateFlowchart?${searchParams.toString()}`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -264,7 +264,7 @@ test.describe('generate flowchart api input tests', () => {
       programIds: '68be11b7-389b-4ebc-9b95-8997e7314497,68be11b7-389b-4ebc-9b95-8997e7314497'
     });
 
-    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const res = await request.get(`/api/util/generateFlowchart?${searchParams.toString()}`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -286,7 +286,7 @@ test.describe('generate flowchart api input tests', () => {
       programIds: '1e292a2d-bdad-43b3-a89e-5ff8fc9b93d3'
     });
 
-    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const res = await request.get(`/api/util/generateFlowchart?${searchParams.toString()}`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -308,7 +308,7 @@ test.describe('generate flowchart api input tests', () => {
       programIds: '1e292a2d-bdad-43b3-a89e-5ff8fc9b93d3,0c1ea546-75ac-4753-9505-bcac01ef8505'
     });
 
-    const res = await request.get(`/api/data/generateFlowchart?${searchParams.toString()}`);
+    const res = await request.get(`/api/util/generateFlowchart?${searchParams.toString()}`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -330,7 +330,7 @@ test.describe('generate flowchart api input tests', () => {
 
     // just standard thing
     const res1 = await request.get(
-      `/api/data/generateFlowchart?${new URLSearchParams({
+      `/api/util/generateFlowchart?${new URLSearchParams({
         name: 'test',
         startYear: '2020',
         programIds: '68be11b7-389b-4ebc-9b95-8997e7314497'
@@ -339,7 +339,7 @@ test.describe('generate flowchart api input tests', () => {
     expect(res1.status()).toBe(200);
 
     const res2 = await request.get(
-      `/api/data/generateFlowchart?${new URLSearchParams({
+      `/api/util/generateFlowchart?${new URLSearchParams({
         name: 'another test!',
         startYear: '2015',
         programIds:
@@ -349,7 +349,7 @@ test.describe('generate flowchart api input tests', () => {
     expect(res2.status()).toBe(200);
 
     const res3 = await request.get(
-      `/api/data/generateFlowchart?${new URLSearchParams({
+      `/api/util/generateFlowchart?${new URLSearchParams({
         name: 'another test!',
         startYear: '2015',
         programIds:
@@ -361,7 +361,7 @@ test.describe('generate flowchart api input tests', () => {
     expect(res3.status()).toBe(200);
 
     const res4 = await request.get(
-      `/api/data/generateFlowchart?${new URLSearchParams({
+      `/api/util/generateFlowchart?${new URLSearchParams({
         name: 'another test!',
         startYear: '2015',
         programIds:
@@ -373,7 +373,7 @@ test.describe('generate flowchart api input tests', () => {
     expect(res4.status()).toBe(200);
 
     const res5 = await request.get(
-      `/api/data/generateFlowchart?${new URLSearchParams({
+      `/api/util/generateFlowchart?${new URLSearchParams({
         name: 'another test!',
         startYear: '2015',
         programIds:
@@ -417,7 +417,7 @@ test.describe('generate flowchart api output tests', () => {
     await performLoginBackend(request, userEmail, 'test');
 
     const res = await request.get(
-      `/api/data/generateFlowchart?${new URLSearchParams({
+      `/api/util/generateFlowchart?${new URLSearchParams({
         name: 'test',
         startYear: '2020',
         programIds: '68be11b7-389b-4ebc-9b95-8997e7314497'
@@ -471,7 +471,7 @@ test.describe('generate flowchart api output tests', () => {
     await performLoginBackend(request, userEmail, 'test');
 
     const res = await request.get(
-      `/api/data/generateFlowchart?${new URLSearchParams({
+      `/api/util/generateFlowchart?${new URLSearchParams({
         name: 'test',
         startYear: '2020',
         programIds: '68be11b7-389b-4ebc-9b95-8997e7314497',
@@ -516,7 +516,7 @@ test.describe('generate flowchart api output tests', () => {
     await performLoginBackend(request, userEmail, 'test');
 
     const res = await request.get(
-      `/api/data/generateFlowchart?${new URLSearchParams({
+      `/api/util/generateFlowchart?${new URLSearchParams({
         name: 'test',
         startYear: '2020',
         programIds: '68be11b7-389b-4ebc-9b95-8997e7314497',
@@ -568,7 +568,7 @@ test.describe('generate flowchart api output tests', () => {
     await performLoginBackend(request, userEmail, 'test');
 
     const res = await request.get(
-      `/api/data/generateFlowchart?${new URLSearchParams({
+      `/api/util/generateFlowchart?${new URLSearchParams({
         name: 'test',
         startYear: '2020',
         programIds: '68be11b7-389b-4ebc-9b95-8997e7314497,b86e20fd-bea0-4b68-9d40-793b447ef700'
@@ -624,7 +624,7 @@ test.describe('generate flowchart api output tests', () => {
     await performLoginBackend(request, userEmail, 'test');
 
     const res = await request.get(
-      `/api/data/generateFlowchart?${new URLSearchParams({
+      `/api/util/generateFlowchart?${new URLSearchParams({
         name: 'test',
         startYear: '2015',
         programIds: 'b3c6505b-3993-40bb-967c-423aaeadc2f6,ac354862-271a-4f0b-86f2-6a79e74bf2db'

--- a/tests/api/searchCatalogApiTests.test.ts
+++ b/tests/api/searchCatalogApiTests.test.ts
@@ -22,7 +22,7 @@ test.describe('searchCatalog API tests', () => {
   });
 
   test('fetch results in 400 without authentication', async ({ request }) => {
-    const res = await request.get('/api/data/searchCatalog');
+    const res = await request.get('/api/data/queryCourseCatalog');
 
     const expectedResponseBody = {
       message: 'Request was unauthenticated. Please authenticate and try again.'
@@ -36,7 +36,7 @@ test.describe('searchCatalog API tests', () => {
     // perform login
     await performLoginBackend(request, userEmail, 'test');
 
-    const res = await request.get('/api/data/searchCatalog');
+    const res = await request.get('/api/data/queryCourseCatalog');
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -54,7 +54,7 @@ test.describe('searchCatalog API tests', () => {
     // perform login
     await performLoginBackend(request, userEmail, 'test');
 
-    const res = await request.get(`/api/data/searchCatalog?catalog=invalid&query=test`);
+    const res = await request.get(`/api/data/queryCourseCatalog?catalog=invalid&query=test`);
 
     const expectedResponseBody = {
       message: 'Invalid input received.',
@@ -72,7 +72,7 @@ test.describe('searchCatalog API tests', () => {
     await performLoginBackend(request, userEmail, 'test');
 
     const res = await request.get(
-      `/api/data/searchCatalog?${new URLSearchParams({
+      `/api/data/queryCourseCatalog?${new URLSearchParams({
         catalog: '2015-2017',
         query: '++data'
       }).toString()}`
@@ -91,7 +91,7 @@ test.describe('searchCatalog API tests', () => {
     await performLoginBackend(request, userEmail, 'test');
 
     const res = await request.get(
-      `/api/data/searchCatalog?${new URLSearchParams({
+      `/api/data/queryCourseCatalog?${new URLSearchParams({
         catalog: '2015-2017',
         query: 'test',
         field: 'invalid'
@@ -114,7 +114,7 @@ test.describe('searchCatalog API tests', () => {
     await performLoginBackend(request, userEmail, 'test');
 
     const res = await request.get(
-      `/api/data/searchCatalog?${new URLSearchParams({
+      `/api/data/queryCourseCatalog?${new URLSearchParams({
         catalog: '2022-2026',
         query: 'Bowling'
       }).toString()}`
@@ -171,7 +171,7 @@ test.describe('searchCatalog API tests', () => {
     await performLoginBackend(request, userEmail, 'test');
 
     const res = await request.get(
-      `/api/data/searchCatalog?${new URLSearchParams({
+      `/api/data/queryCourseCatalog?${new URLSearchParams({
         catalog: '2022-2026',
         query: 'data'
       }).toString()}`
@@ -520,7 +520,7 @@ test.describe('searchCatalog API tests', () => {
     await performLoginBackend(request, userEmail, 'test');
 
     const res = await request.get(
-      `/api/data/searchCatalog?${new URLSearchParams({
+      `/api/data/queryCourseCatalog?${new URLSearchParams({
         catalog: '2022-2026',
         query: 'askldfmvklsdmvklsfmvklsdfmvlksdmvkl'
       }).toString()}`
@@ -544,7 +544,7 @@ test.describe('searchCatalog API tests', () => {
     await performLoginBackend(request, userEmail, 'test');
 
     const res = await request.get(
-      `/api/data/searchCatalog?${new URLSearchParams({
+      `/api/data/queryCourseCatalog?${new URLSearchParams({
         catalog: '2022-2026',
         query: 'data*',
         field: 'id'

--- a/tests/page/flows/search/courseSearchTests.test.ts
+++ b/tests/page/flows/search/courseSearchTests.test.ts
@@ -94,7 +94,7 @@ async function assertCorrectCatalogSearch(
   // perform a search and expect request to go out bc its a new search
   // wrap outgoing call in small delay so we can detect loading
   let failOnRoute = false;
-  await page.route(/\/api\/data\/searchCatalog/, async (route) => {
+  await page.route(/\/api\/data\/queryCourseCatalog/, async (route) => {
     if (failOnRoute) {
       throw new Error('unexpected request to searchCatalog intercepted');
     }
@@ -102,7 +102,7 @@ async function assertCorrectCatalogSearch(
     await new Promise((r) => setTimeout(r, 500));
     await route.continue();
   });
-  const responsePromise = page.waitForResponse(/\/api\/data\/searchCatalog/);
+  const responsePromise = page.waitForResponse(/\/api\/data\/queryCourseCatalog/);
   await page
     .getByRole('searchbox', {
       name: 'course search query input'
@@ -336,11 +336,11 @@ test.describe('course search tests', () => {
 
     // perform a search and expect request to go out bc its a new search
     // wrap outgoing call in small delay so we can detect loading
-    await page.route(/\/api\/data\/searchCatalog/, async (route) => {
+    await page.route(/\/api\/data\/queryCourseCatalog/, async (route) => {
       await new Promise((r) => setTimeout(r, 500));
       await route.continue();
     });
-    const responsePromise = page.waitForResponse(/\/api\/data\/searchCatalog/);
+    const responsePromise = page.waitForResponse(/\/api\/data\/queryCourseCatalog/);
     await page
       .getByRole('searchbox', {
         name: 'course search query input'
@@ -452,11 +452,11 @@ test.describe('course search tests', () => {
 
     // perform a search and expect request to go out bc its a new search
     // wrap outgoing call in small delay so we can detect loading
-    await page.route(/\/api\/data\/searchCatalog/, async (route) => {
+    await page.route(/\/api\/data\/queryCourseCatalog/, async (route) => {
       await new Promise((r) => setTimeout(r, 500));
       await route.continue();
     });
-    const responsePromise = page.waitForResponse(/\/api\/data\/searchCatalog/);
+    const responsePromise = page.waitForResponse(/\/api\/data\/queryCourseCatalog/);
     await page
       .getByRole('searchbox', {
         name: 'course search query input'

--- a/tests/routine/createFlowRoutineTests.test.ts
+++ b/tests/routine/createFlowRoutineTests.test.ts
@@ -42,7 +42,7 @@ test.describe('create flow routine tests', () => {
 
   test('user able to create new flowchart', async ({ page }) => {
     // add delay to query requests to ensure Playwright can capture loading spinner
-    await page.route(/\/api\/data\/generateFlowchart/, async (route) => {
+    await page.route(/\/api\/util\/generateFlowchart/, async (route) => {
       await new Promise((r) => setTimeout(r, 250));
       void route.continue();
     });
@@ -87,7 +87,7 @@ test.describe('create flow routine tests', () => {
     // create and wait for response from network
     // need to start waiting for response before request expected to happen so that it doesn't timeout
     // (need to setup listener before the event fires)
-    const responsePromise = page.waitForResponse(/\/api\/data\/generateFlowchart/);
+    const responsePromise = page.waitForResponse(/\/api\/util\/generateFlowchart/);
     await page.getByRole('button', { name: 'Create' }).click();
     await expect(page.getByRole('button', { name: 'Create' }).locator('span')).toHaveClass(
       /loading/
@@ -170,7 +170,7 @@ test.describe('create flow routine tests', () => {
 
   test('401 case handled properly', async ({ page }) => {
     // mock a 401 response
-    await page.route(/\/api\/data\/generateFlowchart/, async (route) => {
+    await page.route(/\/api\/util\/generateFlowchart/, async (route) => {
       await route.fulfill({
         status: 401,
         contentType: 'application/json',
@@ -216,7 +216,7 @@ test.describe('create flow routine tests', () => {
 
     // create and wait for response from network
     // dont check for loading class bc goes away when dialog is handled (eg immediately)
-    const responsePromise = page.waitForResponse(/\/api\/data\/generateFlowchart/);
+    const responsePromise = page.waitForResponse(/\/api\/util\/generateFlowchart/);
     await page.getByRole('button', { name: 'Create' }).click();
     const response = await responsePromise;
 
@@ -242,7 +242,7 @@ test.describe('create flow routine tests', () => {
 
   test('400 case handled properly', async ({ page }) => {
     // mock a 400 response
-    await page.route(/\/api\/data\/generateFlowchart/, async (route) => {
+    await page.route(/\/api\/util\/generateFlowchart/, async (route) => {
       await route.fulfill({
         status: 400,
         contentType: 'application/json',
@@ -288,7 +288,7 @@ test.describe('create flow routine tests', () => {
 
     // create and wait for response from network
     // dont check for loading class bc goes away when dialog is handled (eg immediately)
-    const responsePromise = page.waitForResponse(/\/api\/data\/generateFlowchart/);
+    const responsePromise = page.waitForResponse(/\/api\/util\/generateFlowchart/);
     await page.getByRole('button', { name: 'Create' }).click();
     const response = await responsePromise;
 
@@ -314,7 +314,7 @@ test.describe('create flow routine tests', () => {
 
   test('500 case handled properly', async ({ page }) => {
     // mock a 500 response
-    await page.route(/\/api\/data\/generateFlowchart/, async (route) => {
+    await page.route(/\/api\/util\/generateFlowchart/, async (route) => {
       await route.fulfill({
         status: 500,
         contentType: 'application/json',
@@ -360,7 +360,7 @@ test.describe('create flow routine tests', () => {
 
     // create and wait for response from network
     // dont check for loading class bc goes away when dialog is handled (eg immediately)
-    const responsePromise = page.waitForResponse(/\/api\/data\/generateFlowchart/);
+    const responsePromise = page.waitForResponse(/\/api\/util\/generateFlowchart/);
     await page.getByRole('button', { name: 'Create' }).click();
     const response = await responsePromise;
 


### PR DESCRIPTION
closes #6.

This PR reorganizes the following API endpoints:

`api/data`:
1. `api/data/getAvailableCatalogs`
2. `api/data/getAvailableStartYears`
3. `api/data/queryAvailableMajors`
4. `api/data/queryAvailablePrograms`
5. `api/data/queryCourseCatalog` (previously `api/data/searchCatalog`)

`api/util`:
1. `api/util/generateFlowchart` (previously `api/data/generateFlowchart`)
2. `api/util/generateFlowchartPDF` (previously `api/data/generatePDF`)

Tests were modified to pass with these changes.