### PR TITLE
feat: update `CourseCache` type around project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ concurrency:
 jobs:
   Lint:
     runs-on: ubuntu-latest
+    env:
+      PUBLIC_PFB_DISCORD_LINK: https://discord.gg/xCadnCRC9f
+      PUBLIC_PFB_GITHUB_LINK: https://github.com/polyflowbuilder/polyflowbuilder
+      PUBLIC_PFB_ANALYTICS_ID:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
+      - run: npm run check
 
   # TODO: unit tests should not need a database!
   UnitTest:

--- a/api/src/dev/api-data-bootstrap.ts
+++ b/api/src/dev/api-data-bootstrap.ts
@@ -6,7 +6,8 @@
 // option to load from FS instead of DB
 
 import fs from 'fs';
-import type { APIData } from '$lib/types';
+import { ObjectSet } from '$lib/common/util/ObjectSet';
+import type { APICourseFull, APIData } from '$lib/types';
 import type {
   Program,
   GECourse,
@@ -23,7 +24,7 @@ export const apiData: APIData = {
   startYears: [],
   programData: [],
 
-  courseData: [],
+  courseData: new Map(),
   geCourseData: [],
   reqCourseData: []
 };
@@ -86,25 +87,28 @@ export function init() {
     }
 
     // add loaded data to apiData
-    apiData.courseData.push({
+    apiData.courseData.set(
       catalog,
-      courses: courses.map((crs) => {
-        const ttoData = termTypicallyOffered.find(
-          (ttoCourse) => ttoCourse.catalog === crs.catalog && ttoCourse.id === crs.id
-        );
-        return {
-          ...crs,
-          dynamicTerms: ttoData
-            ? {
-                termFall: ttoData.termFall,
-                termWinter: ttoData.termWinter,
-                termSpring: ttoData.termSpring,
-                termSummer: ttoData.termSummer
-              }
-            : null
-        };
-      })
-    });
+      new ObjectSet<APICourseFull>(
+        (crs) => crs.id,
+        courses.map((crs) => {
+          const ttoData = termTypicallyOffered.find(
+            (ttoCourse) => ttoCourse.catalog === crs.catalog && ttoCourse.id === crs.id
+          );
+          return {
+            ...crs,
+            dynamicTerms: ttoData
+              ? {
+                  termFall: ttoData.termFall,
+                  termWinter: ttoData.termWinter,
+                  termSpring: ttoData.termSpring,
+                  termSummer: ttoData.termSummer
+                }
+              : null
+          };
+        })
+      )
+    );
     apiData.geCourseData.push(...geCourses);
     apiData.reqCourseData.push(...reqCourseData);
   }

--- a/src/lib/client/stores/apiDataStore.ts
+++ b/src/lib/client/stores/apiDataStore.ts
@@ -1,7 +1,8 @@
 import { writable } from 'svelte/store';
 import { writeOnceStore } from './util';
 import type { Program } from '@prisma/client';
-import type { MajorNameCache, CourseCache } from '$lib/types';
+import type { ObjectSet } from '$lib/common/util/ObjectSet';
+import type { CourseCache, MajorNameCache, APICourseFull } from '$lib/types';
 
 // API data for flowcharts
 export const availableFlowchartStartYears = writeOnceStore<string[]>([]);
@@ -9,6 +10,6 @@ export const availableFlowchartCatalogs = writeOnceStore<string[]>([]);
 
 // API data caches
 export const programCache = writable<Program[]>([]);
-export const courseCache = writable<CourseCache[]>([]);
+export const courseCache = writable<CourseCache>(new Map<string, ObjectSet<APICourseFull>>());
 export const majorNameCache = writable<MajorNameCache[]>([]);
 export const catalogMajorNameCache = writable<Set<string>>(new Set<string>());

--- a/src/lib/client/util/mutateUserDataUtilClient.ts
+++ b/src/lib/client/util/mutateUserDataUtilClient.ts
@@ -19,7 +19,7 @@ export function submitUserDataUpdateChunk(userDataUpdateChunk: UserDataUpdateChu
 // TODO: integrate other types of user data, currently just flowcharts
 export function performUpdate(
   chunksList: UserDataUpdateChunk[],
-  courseCache: CourseCache[],
+  courseCache: CourseCache,
   programCache: Program[]
 ): void {
   userFlowcharts.update((curUserFlowcharts) => {

--- a/src/lib/client/util/unitCounterUtilClient.test.ts
+++ b/src/lib/client/util/unitCounterUtilClient.test.ts
@@ -20,7 +20,7 @@ describe('computeGroupUnits tests', () => {
       total: '0'
     };
 
-    expect(computeGroupUnits(null, [], [])).toStrictEqual(expectedCounts);
+    expect(computeGroupUnits(null, new Map(), [])).toStrictEqual(expectedCounts);
   });
 
   test('standard flowchart, 1 program', () => {
@@ -46,7 +46,7 @@ describe('computeGroupUnits tests', () => {
 
   test('error thrown when unable to find catalog for course', () => {
     expect(() => {
-      computeGroupUnits(TEST_FLOWCHART_SINGLE_PROGRAM_1, [], []);
+      computeGroupUnits(TEST_FLOWCHART_SINGLE_PROGRAM_1, new Map(), []);
     }).toThrowError('could not find catalog for course in flowchart');
   });
 });

--- a/src/lib/client/util/unitCounterUtilClient.ts
+++ b/src/lib/client/util/unitCounterUtilClient.ts
@@ -1,7 +1,10 @@
 import { COLORS } from '$lib/common/config/colorConfig';
 import { SANITIZE_REGEX } from '$lib/common/config/catalogSearchConfig';
 import { incrementRangedUnits } from '$lib/common/util/unitCounterUtilCommon';
-import { getCatalogFromProgramIDIndex } from '$lib/common/util/courseDataUtilCommon';
+import {
+  getCourseFromCourseCache,
+  getCatalogFromProgramIDIndex
+} from '$lib/common/util/courseDataUtilCommon';
 import type { Program } from '@prisma/client';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache, FlowEditorFooterUnitCounts } from '$lib/types';
@@ -11,7 +14,7 @@ import type { CourseCache, FlowEditorFooterUnitCounts } from '$lib/types';
 
 export function computeGroupUnits(
   flowchart: Flowchart | null,
-  courseCache: CourseCache[],
+  courseCache: CourseCache,
   programCache: Program[]
 ): FlowEditorFooterUnitCounts {
   const unitCounts: FlowEditorFooterUnitCounts = {
@@ -46,9 +49,12 @@ export function computeGroupUnits(
         throw new Error('could not find catalog for course in flowchart');
       }
 
-      const courseMetadata = courseCache
-        .find((cache) => cache.catalog === courseCatalog)
-        ?.courses.find((c) => c.id === course.id);
+      const courseMetadata = getCourseFromCourseCache(
+        course,
+        flowchart.programId,
+        courseCache,
+        programCache
+      );
 
       // customUnits takes precedence even if we have a standard course
       // (for standard+customUnit cases)

--- a/src/lib/common/util/ObjectSet.ts
+++ b/src/lib/common/util/ObjectSet.ts
@@ -6,7 +6,7 @@ export class ObjectSet<T> {
   #itemMap: Map<string, T>;
   #keyFunction: (input: T) => string;
 
-  constructor(items: T[] = [], keyFunction: (input: T) => string) {
+  constructor(keyFunction: (input: T) => string, items: T[] = []) {
     this.#itemMap = new Map<string, T>();
     this.#keyFunction = keyFunction;
 

--- a/src/lib/common/util/ObjectSet.ts
+++ b/src/lib/common/util/ObjectSet.ts
@@ -1,0 +1,50 @@
+// ObjectSet class behaves like a set, but for deep objects
+// takes a function to map objects of a certain type to a string ID,
+// used as the key in the internal Map
+
+export class ObjectSet<T> {
+  #itemMap: Map<string, T>;
+  #keyFunction: (input: T) => string;
+
+  constructor(items: T[] = [], keyFunction: (input: T) => string) {
+    this.#itemMap = new Map<string, T>();
+    this.#keyFunction = keyFunction;
+
+    for (const item of items) {
+      this.add(item);
+    }
+  }
+
+  get size() {
+    return this.#itemMap.size;
+  }
+
+  add(item: T) {
+    const key = this.#keyFunction(item);
+    if (!this.#itemMap.has(key)) {
+      this.#itemMap.set(key, item);
+    }
+  }
+
+  get(key: string) {
+    return this.#itemMap.get(key);
+  }
+
+  clear() {
+    this.#itemMap.clear();
+  }
+
+  delete(item: T) {
+    const key = this.#keyFunction(item);
+    return this.#itemMap.delete(key);
+  }
+
+  values() {
+    return this.#itemMap.values();
+  }
+
+  has(item: T) {
+    const key = this.#keyFunction(item);
+    return this.#itemMap.has(key);
+  }
+}

--- a/src/lib/common/util/ObjectSet.ts
+++ b/src/lib/common/util/ObjectSet.ts
@@ -36,6 +36,10 @@ export class ObjectSet<T> {
 
   delete(item: T) {
     const key = this.#keyFunction(item);
+    return this.deleteByKey(key);
+  }
+
+  deleteByKey(key: string) {
     return this.#itemMap.delete(key);
   }
 

--- a/src/lib/common/util/ObjectSet.ts
+++ b/src/lib/common/util/ObjectSet.ts
@@ -43,6 +43,10 @@ export class ObjectSet<T> {
     return this.#itemMap.delete(key);
   }
 
+  keys() {
+    return this.#itemMap.keys();
+  }
+
   values() {
     return this.#itemMap.values();
   }

--- a/src/lib/common/util/courseDataUtilCommon.ts
+++ b/src/lib/common/util/courseDataUtilCommon.ts
@@ -2,7 +2,24 @@
 
 import type { Course } from '$lib/common/schema/flowchartSchema';
 import type { Program } from '@prisma/client';
-import type { APICourseFull, ComputedCourseItemDisplayData } from '$lib/types';
+import type { APICourseFull, ComputedCourseItemDisplayData, CourseCache } from '$lib/types';
+
+export function getCourseFromCourseCache(
+  course: Course,
+  flowProgramId: string[],
+  courseCache: CourseCache,
+  programCache: Program[]
+) {
+  const courseCatalog = getCatalogFromProgramIDIndex(
+    course.programIdIndex ?? 0,
+    flowProgramId,
+    programCache
+  );
+  const courseMetadata =
+    !course.id || !courseCatalog ? null : courseCache.get(courseCatalog)?.get(course.id) ?? null;
+
+  return courseMetadata;
+}
 
 export function getCatalogFromProgramIDIndex(
   programIDIndex: number,

--- a/src/lib/common/util/flowDataUtilCommon.test.ts
+++ b/src/lib/common/util/flowDataUtilCommon.test.ts
@@ -1,5 +1,5 @@
 import * as apiDataConfig from '$lib/server/config/apiDataConfig';
-import { CURRENT_FLOW_DATA_VERSION } from '../config/flowDataConfig';
+import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
 import { generateFlowHash, mergeFlowchartsCourseData } from '$lib/common/util/flowDataUtilCommon';
 import type { CourseCache } from '$lib/types';
 import type { Flowchart, Term } from '$lib/common/schema/flowchartSchema';
@@ -261,13 +261,10 @@ describe('generateFlowHash tests', () => {
 
 describe('mergeFlowchartsCourseData tests', () => {
   test('merging with empty data', () => {
-    expect(mergeFlowchartsCourseData([], [], [], [])).toEqual([]);
+    expect(mergeFlowchartsCourseData([], [], new Map(), [])).toEqual([]);
   });
 
   test('merge single flowchart data', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2015-2017'
-    );
     const flow1TermData: Term[] = [
       {
         tIndex: 1,
@@ -293,16 +290,13 @@ describe('mergeFlowchartsCourseData tests', () => {
       mergeFlowchartsCourseData(
         [flow1TermData],
         ['68be11b7-389b-4ebc-9b95-8997e7314497'],
-        courseCache,
+        apiDataConfig.apiData.courseData,
         apiDataConfig.apiData.programData
       )
     ).toEqual(flow1TermData);
   });
 
   test('merge two flowcharts data with courseMerge set', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2015-2017' || crsData.catalog === '2022-2026'
-    );
     const flow1TermData: Term[] = [
       {
         tIndex: 1,
@@ -407,16 +401,13 @@ describe('mergeFlowchartsCourseData tests', () => {
       mergeFlowchartsCourseData(
         [flow1TermData, flow2TermData],
         ['68be11b7-389b-4ebc-9b95-8997e7314497', 'cb65784d-23d6-44a9-ae7a-03b4b50d5b36'],
-        courseCache,
+        apiDataConfig.apiData.courseData,
         apiDataConfig.apiData.programData
       )
     ).toEqual(combinedFlowDataMerged);
   });
 
   test('merge 2 w/ courseMerge OFF', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2015-2017' || crsData.catalog === '2022-2026'
-    );
     const flow1TermData: Term[] = [
       {
         tIndex: 1,
@@ -531,7 +522,7 @@ describe('mergeFlowchartsCourseData tests', () => {
       mergeFlowchartsCourseData(
         [flow1TermData, flow2TermData],
         ['68be11b7-389b-4ebc-9b95-8997e7314497', 'cb65784d-23d6-44a9-ae7a-03b4b50d5b36'],
-        courseCache,
+        apiDataConfig.apiData.courseData,
         apiDataConfig.apiData.programData,
         false
       )

--- a/src/lib/common/util/flowDataUtilCommon.ts
+++ b/src/lib/common/util/flowDataUtilCommon.ts
@@ -41,7 +41,7 @@ export function generateFlowHash(flow: Flowchart): string {
 export function mergeFlowchartsCourseData(
   flowchartsTermData: Term[][],
   programIdMerged: string[],
-  courseCache: CourseCache[],
+  courseCache: CourseCache,
   programCache: Program[],
   performCourseMerge = true
 ): Term[] {

--- a/src/lib/common/util/mutateUserDataUtilCommon.ts
+++ b/src/lib/common/util/mutateUserDataUtilCommon.ts
@@ -12,7 +12,7 @@ import type { MutateFlowchartData, MutateUserDataUtilCommonResult } from '$lib/t
 export function mutateUserFlowcharts(
   curUserFlowchartsData: MutateFlowchartData[],
   updateChunks: UserDataUpdateChunk[],
-  courseCache: CourseCache[],
+  courseCache: CourseCache,
   programCache: Program[]
 ): MutateUserDataUtilCommonResult {
   const errors: string[] = [];

--- a/src/lib/common/util/unitCounterUtilCommon.test.ts
+++ b/src/lib/common/util/unitCounterUtilCommon.test.ts
@@ -1,12 +1,13 @@
 import * as apiDataConfig from '$lib/server/config/apiDataConfig';
 import { TEST_FLOWCHART_SINGLE_PROGRAM_1 } from '../../../../tests/util/testFlowcharts';
 import {
-  incrementRangedUnits,
   computeTermUnits,
-  computeTotalUnits
+  computeTotalUnits,
+  incrementRangedUnits
 } from '$lib/common/util/unitCounterUtilCommon';
 import type { Course } from '$lib/common/schema/flowchartSchema';
-import type { CourseCache } from '$lib/types';
+import type { ObjectSet } from '$lib/common/util/ObjectSet';
+import type { APICourseFull } from '$lib/types';
 
 // init API data
 await apiDataConfig.init();
@@ -45,9 +46,6 @@ describe('incrementRangedUnits tests', () => {
 
 describe('computeTermUnits tests', () => {
   test('computeTermUnits with term that has no custom courses within one program and catalog', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2021-2022'
-    );
     const termData: Course[] = [
       {
         color: '#FEFD9A',
@@ -67,16 +65,13 @@ describe('computeTermUnits tests', () => {
       computeTermUnits(
         termData,
         ['fd2f33be-3103-4b3d-a17b-94ced0d7998f'],
-        courseCache,
+        apiDataConfig.apiData.courseData,
         apiDataConfig.apiData.programData
       )
     ).toBe('12');
   });
 
   test('computeTermUnits with term that has no custom courses within two programs, one catalog', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2021-2022'
-    );
     const termData: Course[] = [
       {
         color: '#FEFD9A',
@@ -97,16 +92,13 @@ describe('computeTermUnits tests', () => {
       computeTermUnits(
         termData,
         ['fd2f33be-3103-4b3d-a17b-94ced0d7998f', '0edc1eaa-e7fb-40f1-bfef-9382a5bfd776'],
-        courseCache,
+        apiDataConfig.apiData.courseData,
         apiDataConfig.apiData.programData
       )
     ).toBe('12');
   });
 
   test('computeTermUnits with term that has no custom courses within two programs, two catalogs', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2015-2017' || crsData.catalog === '2022-2026'
-    );
     const termData: Course[] = [
       {
         color: '#FEFD9A',
@@ -127,16 +119,13 @@ describe('computeTermUnits tests', () => {
       computeTermUnits(
         termData,
         ['68be11b7-389b-4ebc-9b95-8997e7314497', 'cb65784d-23d6-44a9-ae7a-03b4b50d5b36'],
-        courseCache,
+        apiDataConfig.apiData.courseData,
         apiDataConfig.apiData.programData
       )
     ).toBe('9');
   });
 
   test('computeTermUnits with term that has custom courses, one program and catalog', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2021-2022'
-    );
     const termData: Course[] = [
       {
         color: '#FEFD9A',
@@ -171,16 +160,13 @@ describe('computeTermUnits tests', () => {
       computeTermUnits(
         termData,
         ['fd2f33be-3103-4b3d-a17b-94ced0d7998f'],
-        courseCache,
+        apiDataConfig.apiData.courseData,
         apiDataConfig.apiData.programData
       )
     ).toBe('16-18');
   });
 
   test('computeTermUnits with term that has custom courses, two programs and two catalogs', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2015-2017' || crsData.catalog === '2022-2026'
-    );
     const termData: Course[] = [
       {
         color: '#FEFD9A',
@@ -216,16 +202,13 @@ describe('computeTermUnits tests', () => {
       computeTermUnits(
         termData,
         ['68be11b7-389b-4ebc-9b95-8997e7314497', 'cb65784d-23d6-44a9-ae7a-03b4b50d5b36'],
-        courseCache,
+        apiDataConfig.apiData.courseData,
         apiDataConfig.apiData.programData
       )
     ).toBe('13-15');
   });
 
   test('computeTermUnits with term that has mix of standard, standard+customUnits, and custom courses, one program and catalog', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2021-2022'
-    );
     const termData: Course[] = [
       // standard courses
       {
@@ -268,16 +251,13 @@ describe('computeTermUnits tests', () => {
       computeTermUnits(
         termData,
         ['fd2f33be-3103-4b3d-a17b-94ced0d7998f'],
-        courseCache,
+        apiDataConfig.apiData.courseData,
         apiDataConfig.apiData.programData
       )
     ).toBe('21-26');
   });
 
   test('computeTermUnits unable to find course catalog', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2015-2017'
-    );
     const termData: Course[] = [
       {
         color: '#FEFD9A',
@@ -297,16 +277,17 @@ describe('computeTermUnits tests', () => {
       computeTermUnits(
         termData,
         ['032a4186-fc8a-4614-8c69-b3e43ae21df4'],
-        courseCache,
+        apiDataConfig.apiData.courseData,
         apiDataConfig.apiData.programData
       )
     ).toThrowError('unitCounterUtil: undefined courseCatalog');
   });
 
   test('computeTermUnits unable to find course metadata', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2015-2017'
-    );
+    const courseCache1517Only = new Map([
+      ['2015-2017', apiDataConfig.apiData.courseData.get('2015-2017') as ObjectSet<APICourseFull>]
+    ]);
+
     const termData: Course[] = [
       {
         color: '#FEFD9A',
@@ -326,7 +307,7 @@ describe('computeTermUnits tests', () => {
       computeTermUnits(
         termData,
         ['fd2f33be-3103-4b3d-a17b-94ced0d7998f'],
-        courseCache,
+        courseCache1517Only,
         apiDataConfig.apiData.programData
       )
     ).toThrowError('unitCounterUtil: unable to find course metadata for course AGC301');
@@ -337,37 +318,39 @@ describe('computeTotalUnits tests', () => {
   const flowTermData = TEST_FLOWCHART_SINGLE_PROGRAM_1.termData;
 
   test('compute total units for empty flowchart', () => {
-    expect(computeTotalUnits([], [], [])).toBe('0');
+    expect(computeTotalUnits([], new Map(), [])).toBe('0');
   });
 
   test('compute total units for standard flowchart, no fullCompute', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2021-2022'
-    );
-    expect(computeTotalUnits(flowTermData, courseCache, apiDataConfig.apiData.programData)).toBe(
-      '196-198'
-    );
+    expect(
+      computeTotalUnits(
+        flowTermData,
+        apiDataConfig.apiData.courseData,
+        apiDataConfig.apiData.programData
+      )
+    ).toBe('196-198');
   });
 
   test('compute total units for standard flowchart, fullCompute no programId', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2021-2022'
-    );
-
     expect(() =>
-      computeTotalUnits(flowTermData, courseCache, apiDataConfig.apiData.programData, true)
+      computeTotalUnits(
+        flowTermData,
+        apiDataConfig.apiData.courseData,
+        apiDataConfig.apiData.programData,
+        true
+      )
     ).toThrowError('computeTotalUnits: requested fullCompute with no programId');
   });
 
   test('compute total units for standard flowchart, fullCompute with programId', () => {
-    const courseCache: CourseCache[] = apiDataConfig.apiData.courseData.filter(
-      (crsData) => crsData.catalog === '2021-2022'
-    );
-
     expect(
-      computeTotalUnits(flowTermData, courseCache, apiDataConfig.apiData.programData, true, [
-        'fd2f33be-3103-4b3d-a17b-94ced0d7998f'
-      ])
+      computeTotalUnits(
+        flowTermData,
+        apiDataConfig.apiData.courseData,
+        apiDataConfig.apiData.programData,
+        true,
+        ['fd2f33be-3103-4b3d-a17b-94ced0d7998f']
+      )
     ).toBe('192-194');
   });
 });

--- a/src/lib/common/util/unitCounterUtilCommon.ts
+++ b/src/lib/common/util/unitCounterUtilCommon.ts
@@ -1,6 +1,9 @@
 // util functions related to unit counting
 
-import { getCatalogFromProgramIDIndex } from '$lib/common/util/courseDataUtilCommon';
+import {
+  getCourseFromCourseCache,
+  getCatalogFromProgramIDIndex
+} from '$lib/common/util/courseDataUtilCommon';
 import type { Program } from '@prisma/client';
 import type { CourseCache } from '$lib/types';
 import type { Course, Term } from '$lib/common/schema/flowchartSchema';
@@ -22,7 +25,7 @@ export function computeTermUnits(
   termData: Course[],
   programId: string[],
   // bc we can call from either client or server
-  courseCache: CourseCache[],
+  courseCache: CourseCache,
   programCache: Program[]
 ): string {
   let computedTermUnits = '0';
@@ -40,9 +43,7 @@ export function computeTermUnits(
       if (!courseCatalog) {
         throw new Error('unitCounterUtil: undefined courseCatalog');
       }
-      const courseMetadata = courseCache
-        .find((cache) => cache.catalog === courseCatalog)
-        ?.courses.find((crs) => crs.id === c.id);
+      const courseMetadata = getCourseFromCourseCache(c, programId, courseCache, programCache);
       if (!courseMetadata) {
         throw new Error(`unitCounterUtil: unable to find course metadata for course ${c.id}`);
       }
@@ -55,7 +56,7 @@ export function computeTermUnits(
 
 export function computeTotalUnits(
   termsData: Term[],
-  courseCache: CourseCache[],
+  courseCache: CourseCache,
   programCache: Program[],
   fullCompute = false,
   programId?: string[]

--- a/src/lib/components/Flows/modals/CustomizeCourseModal.svelte
+++ b/src/lib/components/Flows/modals/CustomizeCourseModal.svelte
@@ -3,10 +3,10 @@
   import { userFlowcharts } from '$lib/client/stores/userDataStore';
   import { updateCourseData } from '$lib/client/util/flowActionsUtil';
   import { validateUnitString } from '$lib/client/util/unitCounterUtilClient';
+  import { getCourseFromCourseCache } from '$lib/common/util/courseDataUtilCommon';
   import { courseCache, programCache } from '$lib/client/stores/apiDataStore';
   import { customizeCoursesModalOpen } from '$lib/client/stores/modalStateStore';
   import { UPDATE_CHUNK_DELAY_TIME_MS } from '$lib/client/config/editorConfig';
-  import { getCatalogFromProgramIDIndex } from '$lib/common/util/courseDataUtilCommon';
   import { selectedCourses, selectedFlowIndex } from '$lib/client/stores/UIDataStore';
   import {
     CUSTOM_COURSE_DESC_MAX_LENGTH,
@@ -86,14 +86,12 @@
         newCourseUnits = course.customUnits ?? '0';
       } else {
         // perform lookup if course is standard
-        const courseCatalog = getCatalogFromProgramIDIndex(
-          course.programIdIndex ?? 0,
+        const courseMetadata = getCourseFromCourseCache(
+          course,
           $userFlowcharts[$selectedFlowIndex].programId,
+          $courseCache,
           $programCache
         );
-        const courseMetadata = $courseCache
-          .find((cache) => cache.catalog === courseCatalog)
-          ?.courses.find((c) => c.id === course.id);
 
         if (!courseMetadata) {
           throw new Error('unable to find course metadata for standard course in customize course');

--- a/src/lib/server/config/apiDataConfig.ts
+++ b/src/lib/server/config/apiDataConfig.ts
@@ -1,4 +1,5 @@
 import { prisma } from '$lib/server/db/prisma';
+import { ObjectSet } from '$lib/common/util/ObjectSet';
 import { initLogger } from '$lib/common/config/loggerConfig';
 import type { APICourseFull, APIData } from '$lib/types';
 import type { APICourse, DBNotification } from '@prisma/client';
@@ -10,7 +11,7 @@ export const apiData: APIData = {
   startYears: [],
   programData: [],
 
-  courseData: [],
+  courseData: new Map(),
   geCourseData: [],
   reqCourseData: []
 };
@@ -76,10 +77,15 @@ export async function init(): Promise<void> {
   apiData.programData = dbProgramData;
 
   // initialize course data
-  apiData.courseData = dbCatalogs.map(({ catalog }) => ({
-    catalog,
-    courses: dbCourseData.filter((crs) => crs.catalog === catalog)
-  }));
+  dbCatalogs.forEach(({ catalog }) => {
+    apiData.courseData.set(
+      catalog,
+      new ObjectSet<APICourseFull>(
+        (crs) => crs.id,
+        dbCourseData.filter((crs) => crs.catalog === catalog)
+      )
+    );
+  });
   apiData.geCourseData = dbGECourseData;
   apiData.reqCourseData = dbReqCourseData;
 

--- a/src/lib/server/util/generatePDF.ts
+++ b/src/lib/server/util/generatePDF.ts
@@ -9,8 +9,8 @@ import puppeteer from 'puppeteer';
 import pdfTemplateString from '$lib/../../api/data/flows/exports/flowexport.ejs?raw';
 import { generateTermString } from '$lib/common/util/flowTermUtilCommon';
 import {
-  computeCourseDisplayValues,
-  getCatalogFromProgramIDIndex
+  getCourseFromCourseCache,
+  computeCourseDisplayValues
 } from '$lib/common/util/courseDataUtilCommon';
 import type { Program } from '@prisma/client';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
@@ -19,7 +19,7 @@ import type { FlowchartPDFData, FlowchartPDFTermData } from '$lib/types/generate
 
 export function extractPDFDataFromFlowchart(
   flowchart: Flowchart,
-  courseCache: CourseCache[],
+  courseCache: CourseCache,
   programCache: Program[]
 ): FlowchartPDFData {
   // get program friendly names
@@ -53,19 +53,12 @@ export function extractPDFDataFromFlowchart(
     };
 
     term.courses.forEach((course) => {
-      const courseMetadata =
-        courseCache
-          .find(
-            (cacheEntry) =>
-              cacheEntry.catalog ===
-              getCatalogFromProgramIDIndex(
-                course.programIdIndex ?? 0,
-                flowchart.programId,
-                programCache
-              )
-          )
-          ?.courses.find((c) => c.id === course.id) ?? null;
-
+      const courseMetadata = getCourseFromCourseCache(
+        course,
+        flowchart.programId,
+        courseCache,
+        programCache
+      );
       termData.tData.push(computeCourseDisplayValues(course, courseMetadata, false));
     });
 

--- a/src/lib/types/apiDataTypes.ts
+++ b/src/lib/types/apiDataTypes.ts
@@ -1,8 +1,9 @@
+import type { ObjectSet } from '$lib/common/util/ObjectSet';
 import type {
+  Program,
+  GECourse,
   APICourse,
   CourseRequisite,
-  GECourse,
-  Program,
   TermTypicallyOffered
 } from '@prisma/client';
 
@@ -10,10 +11,7 @@ export type APICourseFull = APICourse & {
   dynamicTerms: Omit<Omit<TermTypicallyOffered, 'id'>, 'catalog'> | null;
 };
 
-export interface CourseCache {
-  catalog: string;
-  courses: APICourseFull[];
-}
+export type CourseCache = Map<string, ObjectSet<APICourseFull>>;
 
 export interface MajorNameCache {
   catalog: string;
@@ -27,7 +25,7 @@ export interface APIData {
   programData: Program[];
 
   // course-related data
-  courseData: CourseCache[];
+  courseData: CourseCache;
   geCourseData: GECourse[];
   reqCourseData: CourseRequisite[];
 }

--- a/src/routes/api/user/data/getUserFlowcharts/+server.ts
+++ b/src/routes/api/user/data/getUserFlowcharts/+server.ts
@@ -56,7 +56,12 @@ export const GET: RequestHandler = async ({ locals, url }) => {
         message: 'User flowchart retrieval successful.',
         flowcharts,
         ...(parseResults.data.includeCourseCache && {
-          courseCache: await generateCourseCacheFlowcharts(flowcharts, programMetadata)
+          // serialize course cache
+          courseCache: Array.from(
+            (await generateCourseCacheFlowcharts(flowcharts, programMetadata)).entries()
+          ).map(([catalog, objectSet]) => {
+            return [catalog, Array.from(objectSet.values())];
+          })
         }),
         ...(parseResults.data.includeProgramMetadata && {
           programMetadata

--- a/src/routes/api/util/generateFlowchart/+server.ts
+++ b/src/routes/api/util/generateFlowchart/+server.ts
@@ -81,7 +81,10 @@ export const GET: RequestHandler = async ({ locals, url }) => {
         message: 'Flowchart successfully generated.',
         generatedFlowchart,
         ...(parseResults.data.generateCourseCache && {
-          courseCache
+          // serialize course cache
+          courseCache: Array.from(courseCache.entries()).map(([catalog, objectSet]) => {
+            return [catalog, Array.from(objectSet.values())];
+          })
         })
       });
     } else {

--- a/src/routes/flows/+page.server.ts
+++ b/src/routes/flows/+page.server.ts
@@ -3,7 +3,7 @@ import { getStartYears } from '$lib/server/db/startYear';
 import { redirectIfAnonymous } from '$lib/server/util/authUtil';
 import type { Program } from '@prisma/client';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
-import type { CourseCache } from '$lib/types';
+import type { APICourseFull } from '$lib/types';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = (event) => {
@@ -11,7 +11,7 @@ export const load: PageServerLoad = (event) => {
 
   async function fetchUserData(): Promise<{
     flowcharts: Flowchart[];
-    courseCache: CourseCache[];
+    courseCache: [string, APICourseFull[]][];
     programMetadata: Program[];
   }> {
     const data = await event.fetch(
@@ -20,7 +20,7 @@ export const load: PageServerLoad = (event) => {
 
     const dataJson = (await data.json()) as {
       flowcharts: Flowchart[];
-      courseCache: CourseCache[];
+      courseCache: [string, APICourseFull[]][];
       programMetadata: Program[];
       message: string;
     };

--- a/src/routes/flows/+page.svelte
+++ b/src/routes/flows/+page.svelte
@@ -2,13 +2,13 @@
   // TODO: put these styles in a better place?
   import 'tippy.js/dist/tippy.css';
   import 'tippy.js/themes/light-border.css';
+  import { ObjectSet } from '$lib/common/util/ObjectSet';
   import { FlowViewer } from '$lib/components/Flows';
   import { searchCache } from '$lib/client/stores/catalogSearchStore.js';
   import { ModalWrapper } from '$lib/components/Flows/modals';
   import { FlowInfoPanel } from '$lib/components/Flows/FlowInfoPanel';
   import { userFlowcharts } from '$lib/client/stores/userDataStore';
   import {
-    selectedColor,
     selectedCourses,
     viewingCreditBin,
     selectedFlowIndex
@@ -33,7 +33,14 @@
   availableFlowchartStartYears.init(data.flowchartStartYears);
 
   // API data caches
-  courseCache.set(data.userData.courseCache);
+  courseCache.set(
+    // deserialize course cache
+    new Map(
+      data.userData.courseCache.map(([catalog, courses]) => {
+        return [catalog, new ObjectSet((crs) => crs.id, courses)];
+      })
+    )
+  );
   programCache.set(data.userData.programMetadata);
 
   // init local stores

--- a/tests/api/generateFlowchartApiTests/expectedResponsePayloads.ts
+++ b/tests/api/generateFlowchartApiTests/expectedResponsePayloads.ts
@@ -1,4 +1,6 @@
+import { ObjectSet } from '$lib/common/util/ObjectSet';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
+import type { APICourseFull } from '$lib/types';
 
 export const responsePayload1 = {
   generatedFlowchart: {
@@ -671,450 +673,489 @@ export const responsePayload1 = {
     publishedId: null,
     importedId: null
   },
-  courseCache: [
-    {
-      catalog: '2015-2017',
-      courses: [
-        {
-          id: 'AERO121',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Fundamentals',
-          units: '2',
-          desc: 'Introduction to the engineering profession including the aeronautical and aerospace fields. Engineering approach to problem-solving and analysis of data obtained from experiments. Basic nomenclature and design criteria used in the aerospace industry. Applications to basic problems in the field. 1 lecture, 1 laboratory.\n',
-          addl: 'Term Typically Offered: F\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATH141',
-          catalog: '2015-2017',
-          displayName: 'Calculus I',
-          units: '4',
-          desc: 'Limits, continuity, differentiation.  Introduction to integration.  4 lectures.  Crosslisted as HNRS/MATH 141.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
-          addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Completion of ELM requirement and passing score on appropriate Mathematics Placement Examination, or MATH 118 and high school trigonometry, or MATH 119.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'IME144',
-          catalog: '2015-2017',
-          displayName: 'Introduction to Design and Manufacturing',
-          units: '4',
-          desc: 'Supplemental review of visualization, sketching, and drafting fundamentals.  Computer-aided solid modeling of parts and assemblies.  Introduction to conventional machining processes on lathes and mills, computer numerical control, quality control, production methods, and design for manufacturing.  Open to all majors.  2 lectures, 2 laboratories.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nRecommended: IME 140 or ME 129 (Formerly ME 151).\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'ENGL134',
-          catalog: '2015-2017',
-          displayName: 'Writing and Rhetoric',
-          units: '4',
-          desc: 'Rhetorical principles and tactics applied to written work.  Writing as a recursive process that leads to greater organizational coherency, stylistic complexity, and rhetorical awareness.  4 lectures.  Fulfills GE A1; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A1.\n',
-          addl: 'GE Area A1\nTerm Typically Offered: F, W, SP\nPrerequisite: Satisfactory score on the English Placement Test.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM124',
-          catalog: '2015-2017',
-          displayName: 'General Chemistry for Physical Science and Engineering I',
-          units: '4',
-          desc: 'Stoichiometry, thermochemistry, atomic structure, bonding, solid-state structures, intermolecular forces, and foundational principles of organic chemistry.  Not open to students with credit in CHEM 127.  Credit will be granted in only one of the following courses:  CHEM 110, CHEM 111, CHEM 124.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
-          addl: 'GE Area B4; GE Area B3\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Passing score on ELM, or an ELM exemption, or credit in MATH 104. Recommended: High school chemistry or equivalent.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATH142',
-          catalog: '2015-2017',
-          displayName: 'Calculus II',
-          units: '4',
-          desc: 'Techniques of integration, applications to physics, transcendental functions.  4 lectures.  Crosslisted as HNRS/MATH 142.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
-          addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 141 with a grade of C- or better or consent of instructor.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'COMS101',
-          catalog: '2015-2017',
-          displayName: 'Public Speaking',
-          units: '4',
-          desc: 'Introduction to the principles of public speaking. Practical experience in the development, presentation, and critical analysis of speeches to inform, to persuade, and to actuate. Not open to students with credit in COMS 102. 4 lectures. Crosslisted as COMS/HNRS 101. Fulfills GE A2; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A2.\n',
-          addl: 'GE Area A2\nTerm Typically Offered: F,W,SP,SU\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'PHYS132',
-          catalog: '2015-2017',
-          displayName: 'General Physics II',
-          units: '4',
-          desc: 'Oscillations, waves in elastic media, sound waves.  Temperature, heat and the first law of thermodynamics.  Kinetic theory of matter, second law of thermodynamics.  Geometrical and physical optics.  3 lectures, 1 laboratory.  Crosslisted as HNRS/PHYS 132.  Fulfills GE B3 & B4.\n',
-          addl: 'GE Area B3; GE Area B4\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: PHYS 131 or HNRS 131 or PHYS 141.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATH143',
-          catalog: '2015-2017',
-          displayName: 'Calculus III',
-          units: '4',
-          desc: 'Infinite sequences and series, vector algebra, curves.  4 lectures.  Crosslisted as HNRS/MATH 143.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
-          addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142 with a grade of C- or better or consent of instructor.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'ENGL149',
-          catalog: '2015-2017',
-          displayName: 'Technical Writing for Engineers',
-          units: '4',
-          desc: 'The principles of technical writing.  Discussion and application of rhetorical principles in technical environments.  Study of methods, resources and common formats used in corporate or research writing.  4 lectures.  Crosslisted as ENGL/HNRS 149.  Fulfills GE A3; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A3.\n',
-          addl: 'GE Area A3\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Completion of GE Area A1 with a C- or better, or consent of instructor; for Engineering students only. Recommended: Completion of GE Area A2.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO215',
-          catalog: '2015-2017',
-          displayName: 'Introduction to Aerospace Design',
-          units: '2',
-          desc: 'Introduction to problem solving techniques and team-centered design projects in aerospace engineering.  Primary emphasis on the solutions of design problems in aerospace engineering using computers.  2 laboratories.\n',
-          addl: 'Term Typically Offered: F, W\nPrerequisite: AERO 121, MATH 143, and IME 144. Recommended: CSC 111.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATH241',
-          catalog: '2015-2017',
-          displayName: 'Calculus IV',
-          units: '4',
-          desc: 'Partial derivatives, multiple integrals, introduction to vector analysis.  4 lectures.  Crosslisted as HNRS/MATH 241.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 143.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'ME211',
-          catalog: '2015-2017',
-          displayName: 'Engineering Statics',
-          units: '3',
-          desc: 'Analysis of forces on engineering structures in equilibrium.  Properties of forces, moments, couples, and resultants.  Equilibrium conditions, friction, centroids, area moments of inertia.  Introduction to mathematical modeling and problem solving.  Vector mathematics where appropriate.  3 lectures.  Crosslisted as HNRS/ME 211.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: MATH 241 (or concurrently), PHYS 131 or PHYS 141.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'PHYS133',
-          catalog: '2015-2017',
-          displayName: 'General Physics III',
-          units: '4',
-          desc: 'Charge and matter, electric field, electric potential, dielectrics, capacitance, current and resistance, electromotive force and circuits, magnetic fields, magnetic field of a moving charge, induced emf.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
-          addl: 'GE Area B3; GE Area B4\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: PHYS 131 or HNRS 131 or PHYS 141, and MATH 142. Recommended: MATH 241.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'BIO213',
-          catalog: '2015-2017',
-          displayName: 'Life Science for Engineers',
-          units: '2',
-          desc: 'Fundamentals of life sciences:  energetics, cell biology, molecular and classical genetics, microbiology, organismal biology, and ecology.  2 lectures.  Fulfills GE B2.\n',
-          addl: 'GE Area B2\nTerm Typically Offered: F, W, SP\nPrerequisite: MATH 142; for engineering students only. Corequisite: BMED/BRAE 213. Recommended: CHEM 124.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'BMED213',
-          catalog: '2015-2017',
-          displayName: 'Bioengineering Fundamentals',
-          units: '2',
-          desc: 'Treatment of the engineering applications of biology.  Genetic engineering and the industrial application of microbiology.  Systems physiology with engineering applications.  Structure and function relationships in biological systems.  The impact of life on its environment.  2 lectures.  Crosslisted as BRAE/BMED 213.  Fulfills GE B2.  Formerly BRAE/ENGR 213.\n',
-          addl: 'GE Area B2\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142; for engineering students only. Corequisite: BIO 213. Recommended: CHEM 124.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATE210',
-          catalog: '2015-2017',
-          displayName: 'Materials Engineering',
-          units: '3',
-          desc: 'Structure of matter.  Physical and mechanical properties of materials including metals, polymers, ceramics, composites, and electronic materials.  Equilibrium diagrams.  Heat treatments, materials selection and corrosion phenomena.  3 lectures.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: CHEM 111 or CHEM 124 or CHEM 127. Recommended: Concurrent enrollment in MATE 215.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'ME212',
-          catalog: '2015-2017',
-          displayName: 'Engineering Dynamics',
-          units: '3',
-          desc: 'Analysis of motions of particles and rigid bodies encountered in engineering.  Velocity, acceleration, relative motion, work, energy, impulse, and momentum.  Further development of mathematical modeling and problem solving.  Vector mathematics where appropriate.  3 lectures.  Crosslisted as HNRS 214/ME 212.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: MATH 241; ME 211 or ARCE 211.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATH244',
-          catalog: '2015-2017',
-          displayName: 'Linear Analysis I',
-          units: '4',
-          desc: 'Separable and linear ordinary differential equations with selected applications; numerical and analytical solutions.  Linear algebra:  vectors in n-space, matrices, linear transformations, eigenvalues, eigenvectors, diagonalization; applications to the study of systems of linear differential equations.  4 lectures.  Crosslisted as HNRS/MATH 244.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 143.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CE204',
-          catalog: '2015-2017',
-          displayName: 'Mechanics of Materials I',
-          units: '3',
-          desc: 'Stresses, strains, and deformations associated with axial, torsional, and flexural loading of bars, shafts, and beams.  Analysis of elementary determinate and indeterminate mechanical and structural systems.  2 lectures, 1 activity.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: ME 211.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO301',
-          catalog: '2015-2017',
-          displayName: 'Aerothermodynamics I',
-          units: '4',
-          desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: ME 211. Corequisite: AERO 300.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO300',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Engineering Analysis',
-          units: '5',
-          desc: 'Analytical methods for aerospace engineering problems.  Topics include vector calculus, linear algebra, differential equations, Laplace transforms and Fourier series.  Computer tools and numerical methods as applied to problems in aerodynamics, structures, stability and control and astronautics.  4 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: AERO 215, MATH 244, ME 211, and PHYS 133.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'STAT312',
-          catalog: '2015-2017',
-          displayName: 'Statistical Methods for Engineers',
-          units: '4',
-          desc: 'Descriptive and graphical methods.  Discrete and continuous probability distributions.  One and two sample confidence intervals and hypothesis testing.  Single factor analysis of variance.  Quality control.  Introduction to regression and to experimental design.  Substantial use of statistical software.  4 lectures.  Fulfills GE B6.\n',
-          addl: 'GE Area B6\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CE207',
-          catalog: '2015-2017',
-          displayName: 'Mechanics of Materials II',
-          units: '2',
-          desc: 'Combined stress states including torsion, axial, shear, moment, and pressure vessel loadings.  Principle stress/strain states.  Basic failure criteria.  Analysis of beam forces, moments, deflections, and rotations.  Introduction to stability concepts including column buckling.  1 lecture, 1 activity.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: CE 204.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO302',
-          catalog: '2015-2017',
-          displayName: 'Aerothermodynamics II',
-          units: '4',
-          desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: AERO 301.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO306',
-          catalog: '2015-2017',
-          displayName: 'Aerodynamics and Flight Performance',
-          units: '4',
-          desc: 'Introduction to theoretical aerodynamics.  Primary emphasis in the subsonic region, including compressibility effects.  Basic aerodynamic theory:  Airfoil theory, wing theory, lift and drag.  Team-centered aerodynamic design.  Flight performance.  4 lectures.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: AERO 215, AERO 301. Concurrent: AERO 302.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'EE201',
-          catalog: '2015-2017',
-          displayName: 'Electric Circuit Theory',
-          units: '3',
-          desc: 'Application of fundamental circuit laws and theorems to the analysis of DC, and steady-state single-phase and three-phase circuits.  Not for electrical engineering majors.  3 lectures.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 244, PHYS 133.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'EE251',
-          catalog: '2015-2017',
-          displayName: 'Electric Circuits Laboratory',
-          units: '1',
-          desc: 'Techniques of measurement of DC and steady-state AC circuit parameters.  Equivalent circuits, nonlinear elements, resonance.  1 laboratory.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nConcurrent: EE 201.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO320',
-          catalog: '2015-2017',
-          displayName: 'Fundamentals of Dynamics and Control',
-          units: '4',
-          desc: 'Introduction to six degree of freedom rigid body dynamic and kinematic equations of motion, including coordinate transformations, Euler angles and quaternions for aerospace vehicles.  Linearization and dynamic system theory and stability.  Introduction to linear control theory, controller design and analysis.  4 lectures.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: AERO 300 and ME 212.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO303',
-          catalog: '2015-2017',
-          displayName: 'Aerothermodynamics III',
-          units: '4',
-          desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: AERO 302.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO304',
-          catalog: '2015-2017',
-          displayName: 'Experimental Aerothermodynamics',
-          units: '2',
-          desc: 'Laboratory experiments verify the momentum and energy equations.  Mass flow rate, fan performance, boundary layer measurements, diffuser performance, and induction pump performance experiments are evaluated.  Introduction to electronic sensors, signals and data acquisition.  1 lecture, 1 laboratory.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: ENGL 149 and AERO 301.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO331',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Structural Analysis I',
-          units: '4',
-          desc: "Deflection analysis.  Principles of fictitious displacement, virtual work, and unit load method.  Energy methods:  Castigliano's theorem, Maxwell-Betti reciprocal theorem, minimum principles, Rayleigh-Ritz's method and Galerkin's method.  Stress analysis of aircraft and spacecraft components.  4 lectures.\n",
-          addl: 'Term Typically Offered: W\nPrerequisite: AERO 300, CE 207, and ME 212.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO420',
-          catalog: '2015-2017',
-          displayName: 'Aircraft Dynamics and Control',
-          units: '4',
-          desc: "Newton's 6-degree-of-freedom equations of motion applied to aerospace vehicles.  Stability and control derivatives, reference frames, steady-state and perturbed dynamic analyses applied to aerospace vehicles.  Stability and control design principles applied to transfer functions, state-space, and modal system dynamics.  4 lectures.\n",
-          addl: 'Term Typically Offered: W\nPrerequisite: AERO 306 and AERO 320.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO307',
-          catalog: '2015-2017',
-          displayName: 'Experimental Aerodynamics',
-          units: '2',
-          desc: 'Wind tunnel testing of basic aerodynamic properties of airfoils, finite wings, aircraft or spacecraft models, and vehicle flight performance.  Emphasis on both static and dynamic responses of aircraft.  Various measurement techniques, data reduction schemes, and analysis methods.  2 laboratories.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: AERO 302, AERO 306, ENGL 149.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO405',
-          catalog: '2015-2017',
-          displayName: 'Supersonic and Hypersonic Aerodynamics',
-          units: '4',
-          desc: 'Review of gas dynamics, shock-wave and boundary-layer interaction, aerodynamic design.  2-dimensional supersonic flows around thin airfoil; finite wing in supersonic flow.  Local surface inclination methods for high-speed flight, boundary-layer and aerodynamic heating, viscous interactions.  4 lectures.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: AERO 303; and AERO 306 or AERO 353.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO431',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Structural Analysis II',
-          units: '4',
-          desc: 'Basic equations of elasticity with applications to typical aerospace structures.  Concepts studied include analysis of aircraft and aerospace structures; airworthiness and airframe loads; structural constraints; elementary aeroelasticity; structural instability; introduction to modern fatigue; fracture mechanics; and composite structures analysis.  4 lectures.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: AERO 331.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO401',
-          catalog: '2015-2017',
-          displayName: 'Propulsion Systems',
-          units: '5',
-          desc: 'Power plant types, components, characteristics, and requirements.  Principles of thrust and energy utilization.  Thermodynamic processes and performance of turboprop, turboshaft, turbofan, turbojet, ramjet, and rocket engines.  4 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: AERO 303, CHEM 124.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO443',
-          catalog: '2015-2017',
-          displayName: 'Aircraft Design I',
-          units: '4',
-          desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  2 lectures, 2 laboratories.  Open to students enrolled in the multidisciplinary design minor.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: Senior standing, IME 144, AERO 215, AERO 303, AERO 306, AERO 331, AERO 405, AERO 420, AERO 431. Concurrent: AERO 401.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO433',
-          catalog: '2015-2017',
-          displayName: 'Experimental Stress Analysis',
-          units: '1',
-          desc: 'Employing the knowledge of stress analysis and aerospace structural analysis in an individual and group design project dealing with aerospace structures.  1 laboratory.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AERO 331, AERO 431.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO460',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Engineering Professional Preparation',
-          units: '1',
-          desc: 'Topics on professional development for student success including resume building and career prospecting, current events in the aerospace industry, graduate studies, engineering ethics, intellectual property, non-disclosure agreements, teamwork, and innovation and entrepreneurship.  1 activity.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: Senior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO444',
-          catalog: '2015-2017',
-          displayName: 'Aircraft Design II',
-          units: '3',
-          desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  3 laboratories.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: AERO 443 and senior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO465',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Systems Senior Laboratory',
-          units: '1',
-          desc: 'Culminating laboratory based experience.  Experiments require the integration of the many disciplines in Aerospace Engineering.  The successful completion of each experiment requires synthesis and integration of the fundamental concepts of the engineering sciences.  Experimentation in the areas of aeroelasticity, active vibration control, inertial navigation, thermal control, hardware-in-the-loop simulation, and momentum exchange.  1 laboratory.\n',
-          addl: 'Term Typically Offered: F, W\nPrerequisite: AERO 303, AERO 304, AERO 320, AERO 431 and Senior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO445',
-          catalog: '2015-2017',
-          displayName: 'Aircraft Design III',
-          units: '3',
-          desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  3 laboratories.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: AERO 444 and senior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        }
-      ]
-    }
-  ] // sort to ensure order of items doesn't matter in cache
-    .map((cache) => {
-      return {
-        catalog: cache.catalog,
-        courses: cache.courses.sort((a, b) => a.id.localeCompare(b.id))
-      };
-    })
-    .sort((a, b) => a.catalog.localeCompare(b.catalog))
+  courseCache: new Map([
+    [
+      '2015-2017',
+      new ObjectSet<APICourseFull>(
+        (crs) => crs.id,
+        [
+          {
+            id: 'AERO121',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Fundamentals',
+            units: '2',
+            desc: 'Introduction to the engineering profession including the aeronautical and aerospace fields. Engineering approach to problem-solving and analysis of data obtained from experiments. Basic nomenclature and design criteria used in the aerospace industry. Applications to basic problems in the field. 1 lecture, 1 laboratory.\n',
+            addl: 'Term Typically Offered: F\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATH141',
+            catalog: '2015-2017',
+            displayName: 'Calculus I',
+            units: '4',
+            desc: 'Limits, continuity, differentiation.  Introduction to integration.  4 lectures.  Crosslisted as HNRS/MATH 141.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
+            addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Completion of ELM requirement and passing score on appropriate Mathematics Placement Examination, or MATH 118 and high school trigonometry, or MATH 119.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'IME144',
+            catalog: '2015-2017',
+            displayName: 'Introduction to Design and Manufacturing',
+            units: '4',
+            desc: 'Supplemental review of visualization, sketching, and drafting fundamentals.  Computer-aided solid modeling of parts and assemblies.  Introduction to conventional machining processes on lathes and mills, computer numerical control, quality control, production methods, and design for manufacturing.  Open to all majors.  2 lectures, 2 laboratories.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nRecommended: IME 140 or ME 129 (Formerly ME 151).\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ENGL134',
+            catalog: '2015-2017',
+            displayName: 'Writing and Rhetoric',
+            units: '4',
+            desc: 'Rhetorical principles and tactics applied to written work.  Writing as a recursive process that leads to greater organizational coherency, stylistic complexity, and rhetorical awareness.  4 lectures.  Fulfills GE A1; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A1.\n',
+            addl: 'GE Area A1\nTerm Typically Offered: F, W, SP\nPrerequisite: Satisfactory score on the English Placement Test.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM124',
+            catalog: '2015-2017',
+            displayName: 'General Chemistry for Physical Science and Engineering I',
+            units: '4',
+            desc: 'Stoichiometry, thermochemistry, atomic structure, bonding, solid-state structures, intermolecular forces, and foundational principles of organic chemistry.  Not open to students with credit in CHEM 127.  Credit will be granted in only one of the following courses:  CHEM 110, CHEM 111, CHEM 124.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
+            addl: 'GE Area B4; GE Area B3\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Passing score on ELM, or an ELM exemption, or credit in MATH 104. Recommended: High school chemistry or equivalent.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATH142',
+            catalog: '2015-2017',
+            displayName: 'Calculus II',
+            units: '4',
+            desc: 'Techniques of integration, applications to physics, transcendental functions.  4 lectures.  Crosslisted as HNRS/MATH 142.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
+            addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 141 with a grade of C- or better or consent of instructor.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'COMS101',
+            catalog: '2015-2017',
+            displayName: 'Public Speaking',
+            units: '4',
+            desc: 'Introduction to the principles of public speaking. Practical experience in the development, presentation, and critical analysis of speeches to inform, to persuade, and to actuate. Not open to students with credit in COMS 102. 4 lectures. Crosslisted as COMS/HNRS 101. Fulfills GE A2; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A2.\n',
+            addl: 'GE Area A2\nTerm Typically Offered: F,W,SP,SU\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'PHYS132',
+            catalog: '2015-2017',
+            displayName: 'General Physics II',
+            units: '4',
+            desc: 'Oscillations, waves in elastic media, sound waves.  Temperature, heat and the first law of thermodynamics.  Kinetic theory of matter, second law of thermodynamics.  Geometrical and physical optics.  3 lectures, 1 laboratory.  Crosslisted as HNRS/PHYS 132.  Fulfills GE B3 & B4.\n',
+            addl: 'GE Area B3; GE Area B4\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: PHYS 131 or HNRS 131 or PHYS 141.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATH143',
+            catalog: '2015-2017',
+            displayName: 'Calculus III',
+            units: '4',
+            desc: 'Infinite sequences and series, vector algebra, curves.  4 lectures.  Crosslisted as HNRS/MATH 143.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
+            addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142 with a grade of C- or better or consent of instructor.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ENGL149',
+            catalog: '2015-2017',
+            displayName: 'Technical Writing for Engineers',
+            units: '4',
+            desc: 'The principles of technical writing.  Discussion and application of rhetorical principles in technical environments.  Study of methods, resources and common formats used in corporate or research writing.  4 lectures.  Crosslisted as ENGL/HNRS 149.  Fulfills GE A3; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A3.\n',
+            addl: 'GE Area A3\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Completion of GE Area A1 with a C- or better, or consent of instructor; for Engineering students only. Recommended: Completion of GE Area A2.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO215',
+            catalog: '2015-2017',
+            displayName: 'Introduction to Aerospace Design',
+            units: '2',
+            desc: 'Introduction to problem solving techniques and team-centered design projects in aerospace engineering.  Primary emphasis on the solutions of design problems in aerospace engineering using computers.  2 laboratories.\n',
+            addl: 'Term Typically Offered: F, W\nPrerequisite: AERO 121, MATH 143, and IME 144. Recommended: CSC 111.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATH241',
+            catalog: '2015-2017',
+            displayName: 'Calculus IV',
+            units: '4',
+            desc: 'Partial derivatives, multiple integrals, introduction to vector analysis.  4 lectures.  Crosslisted as HNRS/MATH 241.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 143.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ME211',
+            catalog: '2015-2017',
+            displayName: 'Engineering Statics',
+            units: '3',
+            desc: 'Analysis of forces on engineering structures in equilibrium.  Properties of forces, moments, couples, and resultants.  Equilibrium conditions, friction, centroids, area moments of inertia.  Introduction to mathematical modeling and problem solving.  Vector mathematics where appropriate.  3 lectures.  Crosslisted as HNRS/ME 211.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: MATH 241 (or concurrently), PHYS 131 or PHYS 141.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'PHYS133',
+            catalog: '2015-2017',
+            displayName: 'General Physics III',
+            units: '4',
+            desc: 'Charge and matter, electric field, electric potential, dielectrics, capacitance, current and resistance, electromotive force and circuits, magnetic fields, magnetic field of a moving charge, induced emf.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
+            addl: 'GE Area B3; GE Area B4\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: PHYS 131 or HNRS 131 or PHYS 141, and MATH 142. Recommended: MATH 241.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'BIO213',
+            catalog: '2015-2017',
+            displayName: 'Life Science for Engineers',
+            units: '2',
+            desc: 'Fundamentals of life sciences:  energetics, cell biology, molecular and classical genetics, microbiology, organismal biology, and ecology.  2 lectures.  Fulfills GE B2.\n',
+            addl: 'GE Area B2\nTerm Typically Offered: F, W, SP\nPrerequisite: MATH 142; for engineering students only. Corequisite: BMED/BRAE 213. Recommended: CHEM 124.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'BMED213',
+            catalog: '2015-2017',
+            displayName: 'Bioengineering Fundamentals',
+            units: '2',
+            desc: 'Treatment of the engineering applications of biology.  Genetic engineering and the industrial application of microbiology.  Systems physiology with engineering applications.  Structure and function relationships in biological systems.  The impact of life on its environment.  2 lectures.  Crosslisted as BRAE/BMED 213.  Fulfills GE B2.  Formerly BRAE/ENGR 213.\n',
+            addl: 'GE Area B2\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142; for engineering students only. Corequisite: BIO 213. Recommended: CHEM 124.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATE210',
+            catalog: '2015-2017',
+            displayName: 'Materials Engineering',
+            units: '3',
+            desc: 'Structure of matter.  Physical and mechanical properties of materials including metals, polymers, ceramics, composites, and electronic materials.  Equilibrium diagrams.  Heat treatments, materials selection and corrosion phenomena.  3 lectures.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: CHEM 111 or CHEM 124 or CHEM 127. Recommended: Concurrent enrollment in MATE 215.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ME212',
+            catalog: '2015-2017',
+            displayName: 'Engineering Dynamics',
+            units: '3',
+            desc: 'Analysis of motions of particles and rigid bodies encountered in engineering.  Velocity, acceleration, relative motion, work, energy, impulse, and momentum.  Further development of mathematical modeling and problem solving.  Vector mathematics where appropriate.  3 lectures.  Crosslisted as HNRS 214/ME 212.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: MATH 241; ME 211 or ARCE 211.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATH244',
+            catalog: '2015-2017',
+            displayName: 'Linear Analysis I',
+            units: '4',
+            desc: 'Separable and linear ordinary differential equations with selected applications; numerical and analytical solutions.  Linear algebra:  vectors in n-space, matrices, linear transformations, eigenvalues, eigenvectors, diagonalization; applications to the study of systems of linear differential equations.  4 lectures.  Crosslisted as HNRS/MATH 244.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 143.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CE204',
+            catalog: '2015-2017',
+            displayName: 'Mechanics of Materials I',
+            units: '3',
+            desc: 'Stresses, strains, and deformations associated with axial, torsional, and flexural loading of bars, shafts, and beams.  Analysis of elementary determinate and indeterminate mechanical and structural systems.  2 lectures, 1 activity.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: ME 211.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO301',
+            catalog: '2015-2017',
+            displayName: 'Aerothermodynamics I',
+            units: '4',
+            desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: ME 211. Corequisite: AERO 300.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO300',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Engineering Analysis',
+            units: '5',
+            desc: 'Analytical methods for aerospace engineering problems.  Topics include vector calculus, linear algebra, differential equations, Laplace transforms and Fourier series.  Computer tools and numerical methods as applied to problems in aerodynamics, structures, stability and control and astronautics.  4 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: AERO 215, MATH 244, ME 211, and PHYS 133.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'STAT312',
+            catalog: '2015-2017',
+            displayName: 'Statistical Methods for Engineers',
+            units: '4',
+            desc: 'Descriptive and graphical methods.  Discrete and continuous probability distributions.  One and two sample confidence intervals and hypothesis testing.  Single factor analysis of variance.  Quality control.  Introduction to regression and to experimental design.  Substantial use of statistical software.  4 lectures.  Fulfills GE B6.\n',
+            addl: 'GE Area B6\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CE207',
+            catalog: '2015-2017',
+            displayName: 'Mechanics of Materials II',
+            units: '2',
+            desc: 'Combined stress states including torsion, axial, shear, moment, and pressure vessel loadings.  Principle stress/strain states.  Basic failure criteria.  Analysis of beam forces, moments, deflections, and rotations.  Introduction to stability concepts including column buckling.  1 lecture, 1 activity.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: CE 204.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO302',
+            catalog: '2015-2017',
+            displayName: 'Aerothermodynamics II',
+            units: '4',
+            desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: AERO 301.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO306',
+            catalog: '2015-2017',
+            displayName: 'Aerodynamics and Flight Performance',
+            units: '4',
+            desc: 'Introduction to theoretical aerodynamics.  Primary emphasis in the subsonic region, including compressibility effects.  Basic aerodynamic theory:  Airfoil theory, wing theory, lift and drag.  Team-centered aerodynamic design.  Flight performance.  4 lectures.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: AERO 215, AERO 301. Concurrent: AERO 302.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'EE201',
+            catalog: '2015-2017',
+            displayName: 'Electric Circuit Theory',
+            units: '3',
+            desc: 'Application of fundamental circuit laws and theorems to the analysis of DC, and steady-state single-phase and three-phase circuits.  Not for electrical engineering majors.  3 lectures.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 244, PHYS 133.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'EE251',
+            catalog: '2015-2017',
+            displayName: 'Electric Circuits Laboratory',
+            units: '1',
+            desc: 'Techniques of measurement of DC and steady-state AC circuit parameters.  Equivalent circuits, nonlinear elements, resonance.  1 laboratory.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nConcurrent: EE 201.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO320',
+            catalog: '2015-2017',
+            displayName: 'Fundamentals of Dynamics and Control',
+            units: '4',
+            desc: 'Introduction to six degree of freedom rigid body dynamic and kinematic equations of motion, including coordinate transformations, Euler angles and quaternions for aerospace vehicles.  Linearization and dynamic system theory and stability.  Introduction to linear control theory, controller design and analysis.  4 lectures.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: AERO 300 and ME 212.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO303',
+            catalog: '2015-2017',
+            displayName: 'Aerothermodynamics III',
+            units: '4',
+            desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: AERO 302.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO304',
+            catalog: '2015-2017',
+            displayName: 'Experimental Aerothermodynamics',
+            units: '2',
+            desc: 'Laboratory experiments verify the momentum and energy equations.  Mass flow rate, fan performance, boundary layer measurements, diffuser performance, and induction pump performance experiments are evaluated.  Introduction to electronic sensors, signals and data acquisition.  1 lecture, 1 laboratory.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: ENGL 149 and AERO 301.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO331',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Structural Analysis I',
+            units: '4',
+            desc: "Deflection analysis.  Principles of fictitious displacement, virtual work, and unit load method.  Energy methods:  Castigliano's theorem, Maxwell-Betti reciprocal theorem, minimum principles, Rayleigh-Ritz's method and Galerkin's method.  Stress analysis of aircraft and spacecraft components.  4 lectures.\n",
+            addl: 'Term Typically Offered: W\nPrerequisite: AERO 300, CE 207, and ME 212.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO420',
+            catalog: '2015-2017',
+            displayName: 'Aircraft Dynamics and Control',
+            units: '4',
+            desc: "Newton's 6-degree-of-freedom equations of motion applied to aerospace vehicles.  Stability and control derivatives, reference frames, steady-state and perturbed dynamic analyses applied to aerospace vehicles.  Stability and control design principles applied to transfer functions, state-space, and modal system dynamics.  4 lectures.\n",
+            addl: 'Term Typically Offered: W\nPrerequisite: AERO 306 and AERO 320.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO307',
+            catalog: '2015-2017',
+            displayName: 'Experimental Aerodynamics',
+            units: '2',
+            desc: 'Wind tunnel testing of basic aerodynamic properties of airfoils, finite wings, aircraft or spacecraft models, and vehicle flight performance.  Emphasis on both static and dynamic responses of aircraft.  Various measurement techniques, data reduction schemes, and analysis methods.  2 laboratories.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: AERO 302, AERO 306, ENGL 149.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO405',
+            catalog: '2015-2017',
+            displayName: 'Supersonic and Hypersonic Aerodynamics',
+            units: '4',
+            desc: 'Review of gas dynamics, shock-wave and boundary-layer interaction, aerodynamic design.  2-dimensional supersonic flows around thin airfoil; finite wing in supersonic flow.  Local surface inclination methods for high-speed flight, boundary-layer and aerodynamic heating, viscous interactions.  4 lectures.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: AERO 303; and AERO 306 or AERO 353.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO431',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Structural Analysis II',
+            units: '4',
+            desc: 'Basic equations of elasticity with applications to typical aerospace structures.  Concepts studied include analysis of aircraft and aerospace structures; airworthiness and airframe loads; structural constraints; elementary aeroelasticity; structural instability; introduction to modern fatigue; fracture mechanics; and composite structures analysis.  4 lectures.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: AERO 331.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO401',
+            catalog: '2015-2017',
+            displayName: 'Propulsion Systems',
+            units: '5',
+            desc: 'Power plant types, components, characteristics, and requirements.  Principles of thrust and energy utilization.  Thermodynamic processes and performance of turboprop, turboshaft, turbofan, turbojet, ramjet, and rocket engines.  4 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: AERO 303, CHEM 124.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO443',
+            catalog: '2015-2017',
+            displayName: 'Aircraft Design I',
+            units: '4',
+            desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  2 lectures, 2 laboratories.  Open to students enrolled in the multidisciplinary design minor.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: Senior standing, IME 144, AERO 215, AERO 303, AERO 306, AERO 331, AERO 405, AERO 420, AERO 431. Concurrent: AERO 401.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO433',
+            catalog: '2015-2017',
+            displayName: 'Experimental Stress Analysis',
+            units: '1',
+            desc: 'Employing the knowledge of stress analysis and aerospace structural analysis in an individual and group design project dealing with aerospace structures.  1 laboratory.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AERO 331, AERO 431.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO460',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Engineering Professional Preparation',
+            units: '1',
+            desc: 'Topics on professional development for student success including resume building and career prospecting, current events in the aerospace industry, graduate studies, engineering ethics, intellectual property, non-disclosure agreements, teamwork, and innovation and entrepreneurship.  1 activity.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: Senior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO444',
+            catalog: '2015-2017',
+            displayName: 'Aircraft Design II',
+            units: '3',
+            desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  3 laboratories.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: AERO 443 and senior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO465',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Systems Senior Laboratory',
+            units: '1',
+            desc: 'Culminating laboratory based experience.  Experiments require the integration of the many disciplines in Aerospace Engineering.  The successful completion of each experiment requires synthesis and integration of the fundamental concepts of the engineering sciences.  Experimentation in the areas of aeroelasticity, active vibration control, inertial navigation, thermal control, hardware-in-the-loop simulation, and momentum exchange.  1 laboratory.\n',
+            addl: 'Term Typically Offered: F, W\nPrerequisite: AERO 303, AERO 304, AERO 320, AERO 431 and Senior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO445',
+            catalog: '2015-2017',
+            displayName: 'Aircraft Design III',
+            units: '3',
+            desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  3 laboratories.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: AERO 444 and senior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          }
+        ]
+      )
+    ]
+  ])
 };
 
 export const responsePayload2 = {
@@ -1840,766 +1881,838 @@ export const responsePayload2 = {
     publishedId: null,
     importedId: null
   },
-  courseCache: [
-    {
-      catalog: '2015-2017',
-      courses: [
-        {
-          id: 'AERO121',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Fundamentals',
-          units: '2',
-          desc: 'Introduction to the engineering profession including the aeronautical and aerospace fields. Engineering approach to problem-solving and analysis of data obtained from experiments. Basic nomenclature and design criteria used in the aerospace industry. Applications to basic problems in the field. 1 lecture, 1 laboratory.\n',
-          addl: 'Term Typically Offered: F\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATH141',
-          catalog: '2015-2017',
-          displayName: 'Calculus I',
-          units: '4',
-          desc: 'Limits, continuity, differentiation.  Introduction to integration.  4 lectures.  Crosslisted as HNRS/MATH 141.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
-          addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Completion of ELM requirement and passing score on appropriate Mathematics Placement Examination, or MATH 118 and high school trigonometry, or MATH 119.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'IME144',
-          catalog: '2015-2017',
-          displayName: 'Introduction to Design and Manufacturing',
-          units: '4',
-          desc: 'Supplemental review of visualization, sketching, and drafting fundamentals.  Computer-aided solid modeling of parts and assemblies.  Introduction to conventional machining processes on lathes and mills, computer numerical control, quality control, production methods, and design for manufacturing.  Open to all majors.  2 lectures, 2 laboratories.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nRecommended: IME 140 or ME 129 (Formerly ME 151).\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'ENGL134',
-          catalog: '2015-2017',
-          displayName: 'Writing and Rhetoric',
-          units: '4',
-          desc: 'Rhetorical principles and tactics applied to written work.  Writing as a recursive process that leads to greater organizational coherency, stylistic complexity, and rhetorical awareness.  4 lectures.  Fulfills GE A1; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A1.\n',
-          addl: 'GE Area A1\nTerm Typically Offered: F, W, SP\nPrerequisite: Satisfactory score on the English Placement Test.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM124',
-          catalog: '2015-2017',
-          displayName: 'General Chemistry for Physical Science and Engineering I',
-          units: '4',
-          desc: 'Stoichiometry, thermochemistry, atomic structure, bonding, solid-state structures, intermolecular forces, and foundational principles of organic chemistry.  Not open to students with credit in CHEM 127.  Credit will be granted in only one of the following courses:  CHEM 110, CHEM 111, CHEM 124.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
-          addl: 'GE Area B4; GE Area B3\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Passing score on ELM, or an ELM exemption, or credit in MATH 104. Recommended: High school chemistry or equivalent.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATH142',
-          catalog: '2015-2017',
-          displayName: 'Calculus II',
-          units: '4',
-          desc: 'Techniques of integration, applications to physics, transcendental functions.  4 lectures.  Crosslisted as HNRS/MATH 142.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
-          addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 141 with a grade of C- or better or consent of instructor.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'COMS101',
-          catalog: '2015-2017',
-          displayName: 'Public Speaking',
-          units: '4',
-          desc: 'Introduction to the principles of public speaking. Practical experience in the development, presentation, and critical analysis of speeches to inform, to persuade, and to actuate. Not open to students with credit in COMS 102. 4 lectures. Crosslisted as COMS/HNRS 101. Fulfills GE A2; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A2.\n',
-          addl: 'GE Area A2\nTerm Typically Offered: F,W,SP,SU\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'PHYS132',
-          catalog: '2015-2017',
-          displayName: 'General Physics II',
-          units: '4',
-          desc: 'Oscillations, waves in elastic media, sound waves.  Temperature, heat and the first law of thermodynamics.  Kinetic theory of matter, second law of thermodynamics.  Geometrical and physical optics.  3 lectures, 1 laboratory.  Crosslisted as HNRS/PHYS 132.  Fulfills GE B3 & B4.\n',
-          addl: 'GE Area B3; GE Area B4\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: PHYS 131 or HNRS 131 or PHYS 141.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATH143',
-          catalog: '2015-2017',
-          displayName: 'Calculus III',
-          units: '4',
-          desc: 'Infinite sequences and series, vector algebra, curves.  4 lectures.  Crosslisted as HNRS/MATH 143.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
-          addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142 with a grade of C- or better or consent of instructor.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'ENGL149',
-          catalog: '2015-2017',
-          displayName: 'Technical Writing for Engineers',
-          units: '4',
-          desc: 'The principles of technical writing.  Discussion and application of rhetorical principles in technical environments.  Study of methods, resources and common formats used in corporate or research writing.  4 lectures.  Crosslisted as ENGL/HNRS 149.  Fulfills GE A3; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A3.\n',
-          addl: 'GE Area A3\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Completion of GE Area A1 with a C- or better, or consent of instructor; for Engineering students only. Recommended: Completion of GE Area A2.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO215',
-          catalog: '2015-2017',
-          displayName: 'Introduction to Aerospace Design',
-          units: '2',
-          desc: 'Introduction to problem solving techniques and team-centered design projects in aerospace engineering.  Primary emphasis on the solutions of design problems in aerospace engineering using computers.  2 laboratories.\n',
-          addl: 'Term Typically Offered: F, W\nPrerequisite: AERO 121, MATH 143, and IME 144. Recommended: CSC 111.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATH241',
-          catalog: '2015-2017',
-          displayName: 'Calculus IV',
-          units: '4',
-          desc: 'Partial derivatives, multiple integrals, introduction to vector analysis.  4 lectures.  Crosslisted as HNRS/MATH 241.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 143.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'ME211',
-          catalog: '2015-2017',
-          displayName: 'Engineering Statics',
-          units: '3',
-          desc: 'Analysis of forces on engineering structures in equilibrium.  Properties of forces, moments, couples, and resultants.  Equilibrium conditions, friction, centroids, area moments of inertia.  Introduction to mathematical modeling and problem solving.  Vector mathematics where appropriate.  3 lectures.  Crosslisted as HNRS/ME 211.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: MATH 241 (or concurrently), PHYS 131 or PHYS 141.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'PHYS133',
-          catalog: '2015-2017',
-          displayName: 'General Physics III',
-          units: '4',
-          desc: 'Charge and matter, electric field, electric potential, dielectrics, capacitance, current and resistance, electromotive force and circuits, magnetic fields, magnetic field of a moving charge, induced emf.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
-          addl: 'GE Area B3; GE Area B4\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: PHYS 131 or HNRS 131 or PHYS 141, and MATH 142. Recommended: MATH 241.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'BIO213',
-          catalog: '2015-2017',
-          displayName: 'Life Science for Engineers',
-          units: '2',
-          desc: 'Fundamentals of life sciences:  energetics, cell biology, molecular and classical genetics, microbiology, organismal biology, and ecology.  2 lectures.  Fulfills GE B2.\n',
-          addl: 'GE Area B2\nTerm Typically Offered: F, W, SP\nPrerequisite: MATH 142; for engineering students only. Corequisite: BMED/BRAE 213. Recommended: CHEM 124.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'BMED213',
-          catalog: '2015-2017',
-          displayName: 'Bioengineering Fundamentals',
-          units: '2',
-          desc: 'Treatment of the engineering applications of biology.  Genetic engineering and the industrial application of microbiology.  Systems physiology with engineering applications.  Structure and function relationships in biological systems.  The impact of life on its environment.  2 lectures.  Crosslisted as BRAE/BMED 213.  Fulfills GE B2.  Formerly BRAE/ENGR 213.\n',
-          addl: 'GE Area B2\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142; for engineering students only. Corequisite: BIO 213. Recommended: CHEM 124.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATE210',
-          catalog: '2015-2017',
-          displayName: 'Materials Engineering',
-          units: '3',
-          desc: 'Structure of matter.  Physical and mechanical properties of materials including metals, polymers, ceramics, composites, and electronic materials.  Equilibrium diagrams.  Heat treatments, materials selection and corrosion phenomena.  3 lectures.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: CHEM 111 or CHEM 124 or CHEM 127. Recommended: Concurrent enrollment in MATE 215.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'ME212',
-          catalog: '2015-2017',
-          displayName: 'Engineering Dynamics',
-          units: '3',
-          desc: 'Analysis of motions of particles and rigid bodies encountered in engineering.  Velocity, acceleration, relative motion, work, energy, impulse, and momentum.  Further development of mathematical modeling and problem solving.  Vector mathematics where appropriate.  3 lectures.  Crosslisted as HNRS 214/ME 212.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: MATH 241; ME 211 or ARCE 211.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'MATH244',
-          catalog: '2015-2017',
-          displayName: 'Linear Analysis I',
-          units: '4',
-          desc: 'Separable and linear ordinary differential equations with selected applications; numerical and analytical solutions.  Linear algebra:  vectors in n-space, matrices, linear transformations, eigenvalues, eigenvectors, diagonalization; applications to the study of systems of linear differential equations.  4 lectures.  Crosslisted as HNRS/MATH 244.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 143.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CE204',
-          catalog: '2015-2017',
-          displayName: 'Mechanics of Materials I',
-          units: '3',
-          desc: 'Stresses, strains, and deformations associated with axial, torsional, and flexural loading of bars, shafts, and beams.  Analysis of elementary determinate and indeterminate mechanical and structural systems.  2 lectures, 1 activity.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: ME 211.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO301',
-          catalog: '2015-2017',
-          displayName: 'Aerothermodynamics I',
-          units: '4',
-          desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: ME 211. Corequisite: AERO 300.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO300',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Engineering Analysis',
-          units: '5',
-          desc: 'Analytical methods for aerospace engineering problems.  Topics include vector calculus, linear algebra, differential equations, Laplace transforms and Fourier series.  Computer tools and numerical methods as applied to problems in aerodynamics, structures, stability and control and astronautics.  4 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: AERO 215, MATH 244, ME 211, and PHYS 133.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'STAT312',
-          catalog: '2015-2017',
-          displayName: 'Statistical Methods for Engineers',
-          units: '4',
-          desc: 'Descriptive and graphical methods.  Discrete and continuous probability distributions.  One and two sample confidence intervals and hypothesis testing.  Single factor analysis of variance.  Quality control.  Introduction to regression and to experimental design.  Substantial use of statistical software.  4 lectures.  Fulfills GE B6.\n',
-          addl: 'GE Area B6\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CE207',
-          catalog: '2015-2017',
-          displayName: 'Mechanics of Materials II',
-          units: '2',
-          desc: 'Combined stress states including torsion, axial, shear, moment, and pressure vessel loadings.  Principle stress/strain states.  Basic failure criteria.  Analysis of beam forces, moments, deflections, and rotations.  Introduction to stability concepts including column buckling.  1 lecture, 1 activity.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: CE 204.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO302',
-          catalog: '2015-2017',
-          displayName: 'Aerothermodynamics II',
-          units: '4',
-          desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: AERO 301.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO306',
-          catalog: '2015-2017',
-          displayName: 'Aerodynamics and Flight Performance',
-          units: '4',
-          desc: 'Introduction to theoretical aerodynamics.  Primary emphasis in the subsonic region, including compressibility effects.  Basic aerodynamic theory:  Airfoil theory, wing theory, lift and drag.  Team-centered aerodynamic design.  Flight performance.  4 lectures.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: AERO 215, AERO 301. Concurrent: AERO 302.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'EE201',
-          catalog: '2015-2017',
-          displayName: 'Electric Circuit Theory',
-          units: '3',
-          desc: 'Application of fundamental circuit laws and theorems to the analysis of DC, and steady-state single-phase and three-phase circuits.  Not for electrical engineering majors.  3 lectures.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 244, PHYS 133.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'EE251',
-          catalog: '2015-2017',
-          displayName: 'Electric Circuits Laboratory',
-          units: '1',
-          desc: 'Techniques of measurement of DC and steady-state AC circuit parameters.  Equivalent circuits, nonlinear elements, resonance.  1 laboratory.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nConcurrent: EE 201.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO320',
-          catalog: '2015-2017',
-          displayName: 'Fundamentals of Dynamics and Control',
-          units: '4',
-          desc: 'Introduction to six degree of freedom rigid body dynamic and kinematic equations of motion, including coordinate transformations, Euler angles and quaternions for aerospace vehicles.  Linearization and dynamic system theory and stability.  Introduction to linear control theory, controller design and analysis.  4 lectures.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: AERO 300 and ME 212.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO303',
-          catalog: '2015-2017',
-          displayName: 'Aerothermodynamics III',
-          units: '4',
-          desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: AERO 302.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO304',
-          catalog: '2015-2017',
-          displayName: 'Experimental Aerothermodynamics',
-          units: '2',
-          desc: 'Laboratory experiments verify the momentum and energy equations.  Mass flow rate, fan performance, boundary layer measurements, diffuser performance, and induction pump performance experiments are evaluated.  Introduction to electronic sensors, signals and data acquisition.  1 lecture, 1 laboratory.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: ENGL 149 and AERO 301.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO331',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Structural Analysis I',
-          units: '4',
-          desc: "Deflection analysis.  Principles of fictitious displacement, virtual work, and unit load method.  Energy methods:  Castigliano's theorem, Maxwell-Betti reciprocal theorem, minimum principles, Rayleigh-Ritz's method and Galerkin's method.  Stress analysis of aircraft and spacecraft components.  4 lectures.\n",
-          addl: 'Term Typically Offered: W\nPrerequisite: AERO 300, CE 207, and ME 212.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO420',
-          catalog: '2015-2017',
-          displayName: 'Aircraft Dynamics and Control',
-          units: '4',
-          desc: "Newton's 6-degree-of-freedom equations of motion applied to aerospace vehicles.  Stability and control derivatives, reference frames, steady-state and perturbed dynamic analyses applied to aerospace vehicles.  Stability and control design principles applied to transfer functions, state-space, and modal system dynamics.  4 lectures.\n",
-          addl: 'Term Typically Offered: W\nPrerequisite: AERO 306 and AERO 320.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO307',
-          catalog: '2015-2017',
-          displayName: 'Experimental Aerodynamics',
-          units: '2',
-          desc: 'Wind tunnel testing of basic aerodynamic properties of airfoils, finite wings, aircraft or spacecraft models, and vehicle flight performance.  Emphasis on both static and dynamic responses of aircraft.  Various measurement techniques, data reduction schemes, and analysis methods.  2 laboratories.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: AERO 302, AERO 306, ENGL 149.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO405',
-          catalog: '2015-2017',
-          displayName: 'Supersonic and Hypersonic Aerodynamics',
-          units: '4',
-          desc: 'Review of gas dynamics, shock-wave and boundary-layer interaction, aerodynamic design.  2-dimensional supersonic flows around thin airfoil; finite wing in supersonic flow.  Local surface inclination methods for high-speed flight, boundary-layer and aerodynamic heating, viscous interactions.  4 lectures.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: AERO 303; and AERO 306 or AERO 353.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO431',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Structural Analysis II',
-          units: '4',
-          desc: 'Basic equations of elasticity with applications to typical aerospace structures.  Concepts studied include analysis of aircraft and aerospace structures; airworthiness and airframe loads; structural constraints; elementary aeroelasticity; structural instability; introduction to modern fatigue; fracture mechanics; and composite structures analysis.  4 lectures.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: AERO 331.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO401',
-          catalog: '2015-2017',
-          displayName: 'Propulsion Systems',
-          units: '5',
-          desc: 'Power plant types, components, characteristics, and requirements.  Principles of thrust and energy utilization.  Thermodynamic processes and performance of turboprop, turboshaft, turbofan, turbojet, ramjet, and rocket engines.  4 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: AERO 303, CHEM 124.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO443',
-          catalog: '2015-2017',
-          displayName: 'Aircraft Design I',
-          units: '4',
-          desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  2 lectures, 2 laboratories.  Open to students enrolled in the multidisciplinary design minor.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: Senior standing, IME 144, AERO 215, AERO 303, AERO 306, AERO 331, AERO 405, AERO 420, AERO 431. Concurrent: AERO 401.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO433',
-          catalog: '2015-2017',
-          displayName: 'Experimental Stress Analysis',
-          units: '1',
-          desc: 'Employing the knowledge of stress analysis and aerospace structural analysis in an individual and group design project dealing with aerospace structures.  1 laboratory.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AERO 331, AERO 431.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO460',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Engineering Professional Preparation',
-          units: '1',
-          desc: 'Topics on professional development for student success including resume building and career prospecting, current events in the aerospace industry, graduate studies, engineering ethics, intellectual property, non-disclosure agreements, teamwork, and innovation and entrepreneurship.  1 activity.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: Senior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO444',
-          catalog: '2015-2017',
-          displayName: 'Aircraft Design II',
-          units: '3',
-          desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  3 laboratories.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: AERO 443 and senior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO465',
-          catalog: '2015-2017',
-          displayName: 'Aerospace Systems Senior Laboratory',
-          units: '1',
-          desc: 'Culminating laboratory based experience.  Experiments require the integration of the many disciplines in Aerospace Engineering.  The successful completion of each experiment requires synthesis and integration of the fundamental concepts of the engineering sciences.  Experimentation in the areas of aeroelasticity, active vibration control, inertial navigation, thermal control, hardware-in-the-loop simulation, and momentum exchange.  1 laboratory.\n',
-          addl: 'Term Typically Offered: F, W\nPrerequisite: AERO 303, AERO 304, AERO 320, AERO 431 and Senior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'AERO445',
-          catalog: '2015-2017',
-          displayName: 'Aircraft Design III',
-          units: '3',
-          desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  3 laboratories.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: AERO 444 and senior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        }
-      ]
-    },
-    {
-      catalog: '2022-2026',
-      courses: [
-        {
-          id: 'CHEM125',
-          catalog: '2022-2026',
-          displayName: 'General Chemistry for Physical Science and Engineering II',
-          units: '4',
-          desc: 'Topics include solution chemistry, thermodynamics, kinetics, equilibrium (including acids and bases), electrochemistry, and nuclear chemistry.  Not open to students with credit in CHEM 128.  3 lectures, 1 laboratory.  Fulfills GE Areas B1 and B3 (GE Areas B3 and B4 for students on the 2019-20 or earlier catalogs).\n',
-          addl: 'Term Typically Offered: F, W, SP\n2020-21 or later catalog: GE Area B1\n2020-21 or later catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B4\nPrerequisite: CHEM 124, or AP Chemistry score of 5.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'BIO161',
-          catalog: '2022-2026',
-          displayName: 'Introduction to Cell and Molecular Biology',
-          units: '4',
-          desc: 'Fundamentals of cellular biology with an emphasis on the molecular perspective of life:  biomolecules, cellular energetics, cell structure and reproduction, molecular mechanisms of genetics and gene expression.  3 lectures, 1 laboratory.  Fulfills GE Areas B2 and B3 (GE Areas B2 and B4 for students on the 2019-20 or earlier catalogs).\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\n2020-21 or later catalog: GE Area B2\n2020-21 or later catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B2\n2019-20 or earlier catalog: GE Area B4\nRecommended: CHEM 110 or CHEM 124 or CHEM 127.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM126',
-          catalog: '2022-2026',
-          displayName: 'General Chemistry for Physical Science and Engineering III',
-          units: '4',
-          desc: 'Topics in equilibrium, kinetics, acid-base chemistry, and molecular structure, contextualized within major sub-disciplines of chemistry.  Not open to students with credit in CHEM 129.  3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: CHEM 125 with a grade of C- or better or consent of instructor.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'PHYS141',
-          catalog: '2022-2026',
-          displayName: 'General Physics I',
-          units: '4',
-          desc: 'Fundamental principles of mechanics.  Vectors, particle kinematics.  Equilibrium of a rigid body.  Work and energy, linear momentum, rotational kinematics and dynamics.  Primarily for engineering and science students.  Course may be offered in classroom-based or online format.  4 lectures.  Crosslisted as HNRS 134/PHYS 141.  Fulfills GE Area B1 (GE Area B3 for students on the 2019-20 or earlier catalogs).\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\n2020-21 or later catalog: GE Area B1\n2019-20 or earlier catalog: GE Area B3\nPrerequisite: MATH 141 with grade C- or better. Corequisite: MATH 142 or MATH 182. Recommended: High School Physics.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'COMS126',
-          catalog: '2022-2026',
-          displayName: 'Argument and Advocacy',
-          units: '4',
-          desc: 'The nature of critical thinking as applied in oral and written argument.  Study of inductive and deductive reasoning.  Analysis of reasoning, argument, forms of support and fallacies of argument and language.  Instruction in and practical experience in crafting sound persuasive arguments and engaging in oral argumentation.  Course may be offered in classroom-based or hybrid format.  4 lectures.   Fulfills GE Area A3 with a grade of C- or better.\n',
-          addl: 'Term Typically Offered: F\n2020-21 or later catalog: GE Area A3\n2019-20 or earlier catalog: GE Area A3\nPrerequisite: Completion of GE Area A2 with a grade of C- or better (GE Area A1 for student on the 2019-20 or an earlier catalog). Recommended: Completion of GE Area A1 with a grade of C- or better (GE Area A2 for student on the 2019-20 or an earlier catalog).\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM216',
-          catalog: '2022-2026',
-          displayName: 'Organic Chemistry I',
-          units: '5',
-          desc: 'Fundamental concepts and laboratory skills of organic chemistry.  Structure, bonding, nomenclature, isomerism, stereochemistry and physical properties of organic compounds.  Introduction to spectroscopy.  Reactions and mechanisms of alkanes, alkenes and alkyl halides.  Fundamental laboratory techniques in organic chemistry.  Not open to students with credit in CHEM 316.  4 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: F, W\nPrerequisite: CHEM 126 or CHEM 129 with a grade of C- or better or consent of instructor.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM331',
-          catalog: '2022-2026',
-          displayName: 'Quantitative Analysis',
-          units: '5',
-          desc: 'Theory and application of chemical equilibrium to analytical problems.  Survey of important analytical methods with stress placed on the theory and application associated with titrimetric and spectrophotometric analysis.  3 lectures, 2 laboratories.\n',
-          addl: 'Term Typically Offered: F, SP, SU\nPrerequisite: CHEM 126 or CHEM 129.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'PHYS142',
-          catalog: '2022-2026',
-          displayName: 'General Physics II',
-          units: '4',
-          desc: 'Oscillations, waves in elastic media, sound waves.  Temperature, heat and the first law of thermodynamics.  Kinetic theory of matter, second law of thermodynamics.  Geometrical and physical optics.  3 lectures, 1 laboratory.  Crosslisted as HNRS 132/PHYS 142.  Fulfills GE Areas B1 and B3 (GE Areas B3 and B4 for students on the 2019-20 or earlier catalogs).  Formerly PHYS 132.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\n2020-21 or later catalog: GE Area B1\n2020-21 or later catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B4\nPrerequisite: PHYS 141; and MATH 142 or MATH 182.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM203',
-          catalog: '2022-2026',
-          displayName: 'Undergraduate Seminar I',
-          units: '1',
-          desc: 'Introduction to basic scientific literature and scientific presentation skills.  Targeted advising and preparation for research and career opportunities.  Designed for second-year students majoring in Biochemistry or in Chemistry.  Credit/No Credit grading only.  1 seminar.\n',
-          addl: 'Term Typically Offered: W, SP\nCR/NC\nPrerequisite: CHEM 126.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM217',
-          catalog: '2022-2026',
-          displayName: 'Organic Chemistry II',
-          units: '3',
-          desc: 'Properties and reactions of carbonyl compounds, alcohols, ethers, amines and carbohydrates with an in-depth treatment of the reaction mechanisms.  Introductory concepts and applications of infrared and NMR spectroscopy.  Not open to students with credit in CHEM 317.  3 lectures.\n',
-          addl: 'Term Typically Offered: W, SP\nPrerequisite: CHEM 216 with a grade of C- or better or consent of instructor. Corequisite: CHEM 221 for Chemistry and Biochemistry majors; or CHEM 220 for non-Chemistry and non-Biochemistry majors.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM221',
-          catalog: '2022-2026',
-          displayName: 'Organic Chemistry Laboratory II',
-          units: '2',
-          desc: 'Laboratory experiments exploring reactions in organic chemistry, applying fundamental laboratory techniques covered in CHEM 216.  2 laboratories.\n',
-          addl: 'Term Typically Offered: W, SP\nPrerequisite: major in Chemistry or Biochemistry. Corequisite: CHEM 217.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'PHYS143',
-          catalog: '2022-2026',
-          displayName: 'General Physics III',
-          units: '4',
-          desc: 'Charge and matter, electric field, electric potential, dielectrics, capacitance, current and resistance, electromotive force and circuits, magnetic fields, magnetic field of a moving charge, induced emf.  3 lectures, 1 laboratory.  Fulfills GE Areas B1 and B3 (GE Areas B3 and B4 for students on the 2019-20 or earlier catalogs).  Formerly PHYS 133.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\n2020-21 or later catalog: GE Area B1\n2020-21 or later catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B4\nPrerequisite: MATH 142 and PHYS 141. Recommended: MATH 241.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM218',
-          catalog: '2022-2026',
-          displayName: 'Organic Chemistry III',
-          units: '3',
-          desc: 'Properties and reactions of alkynes, heterocyclic and aromatic compounds with an in-depth treatment of the mechanisms of the reactions.  Introductory concepts and applications of ultraviolet spectroscopy and mass spectrometry.  Not open to students with credit in CHEM 318.  3 lectures.\n',
-          addl: 'Term Typically Offered: F, SP\nPrerequisite: CHEM 217 with a grade of C- or better or consent of instructor. Corequisite: CHEM 324 for Chemistry and Biochemistry majors; or CHEM 223 for non-Chemistry and non-Biochemistry majors.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM324',
-          catalog: '2022-2026',
-          displayName: 'Organic Chemistry Laboratory III',
-          units: '2',
-          desc: 'Practice in multiple step organic synthesis, column chromatography, vacuum distillation, enzymes as chemical reagents, inert atmosphere techniques, introduction to FT NMR spectroscopy and mass spectrometry, survey of organic chemical literature.  2 laboratories.\n',
-          addl: 'Term Typically Offered: F, SP\nPrerequisite: major in Chemistry or Biochemistry. Corequisite: CHEM 218.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM369',
-          catalog: '2022-2026',
-          displayName: 'Biochemical Principles',
-          units: '5',
-          desc: 'Chemistry and function of major cellular constituents:  proteins, lipids, carbohydrates, nucleic acids, and membranes.  Mechanisms of protein function and regulation and enzyme catalysis.  4 lectures, 1 laboratory.   Fulfills GE Area Upper-Division B (GE Areas B5, B6, or B7 for students on the 2019-20 catalog).\n',
-          addl: 'Term Typically Offered: F, W, SP\n2020-21 or later: Upper-Div GE Area B\n2019-20 or earlier catalog: GE Area B5, B6, or B7\nPrerequisite: Junior standing; completion of GE Area A with grades C- or better; completion of GE Area B1 (GE Area B3 for students on the 2019-20 or earlier catalogs); one course in GE Area B4 with a grade of C- or better (GE Area B1 for students on the 2019-20 or earlier catalogs); BIO 161; and CHEM 217 or CHEM 317.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM303',
-          catalog: '2022-2026',
-          displayName: 'Undergraduate Seminar II',
-          units: '1',
-          desc: 'Advanced exploration of more sophisticated scientific literature and scientific presentation skills.  Targeted advising and preparation for research and career opportunities.  Designed for third-year CHEM and BCHM majors.  Credit/No Credit grading only.  1 seminar.\n',
-          addl: 'Term Typically Offered: F, W, SP\nCR/NC\nPrerequisite: CHEM 203 and CHEM 218.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM372',
-          catalog: '2022-2026',
-          displayName: 'Metabolism',
-          units: '4',
-          desc: 'Intermediary metabolism of carbohydrates, lipids, amino acids and nucleotides, regulation and integration of metabolic pathways, bioenergetics, photosynthesis, electron transport, nitrogen fixation, biochemical function of vitamins and minerals.  4 lectures.\n',
-          addl: 'Term Typically Offered: F, SP\nPrerequisite: CHEM 369 or CHEM 371.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM444',
-          catalog: '2022-2026',
-          displayName: 'Polymers & Coatings I',
-          units: '3',
-          desc: 'Physical properties of polymers and coatings and their measurement.  Molecular weight averages, glass transition, thermodynamics of polymers.  Viscoelastic properties, rheology, molecular weight determination.  Thermal analysis, spectroscopic analysis, mechanical testing.  3 lectures.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: CHEM 212/312 or CHEM 216/316.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM447',
-          catalog: '2022-2026',
-          displayName: 'Polymers and Coatings Laboratory I',
-          units: '2',
-          desc: 'Experimental techniques of producing and characterizing coatings.  Polymer characterization and analysis.  Molecular weight analysis using viscometry, light scattering, and gel permeation chromatography.  Thermal analysis using differential scanning calorimetry, thermal mechanical analysis and dynamic mechanical analysis.  Polymer rheology.  Infrared, Raman and FT-NMR spectroscopy.  Atomic force microscopy.  2 laboratories.\n',
-          addl: 'Term Typically Offered: F\nCorequisite: CHEM 444.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM373',
-          catalog: '2022-2026',
-          displayName: 'Molecular Biology',
-          units: '3',
-          desc: 'Structure of nucleic acids and chromosomes.  Mechanisms and regulation of nucleic acid and protein synthesis.  Molecular biology techniques.  3 lectures.\n',
-          addl: 'Term Typically Offered: W, SP\nPrerequisite: CHEM 369 or CHEM 371.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM351',
-          catalog: '2022-2026',
-          displayName: 'Physical Chemistry I',
-          units: '3',
-          desc: 'Basic physical chemistry for the study of chemical and biochemical systems.  Kinetic-molecular theory, gas laws, principles of thermodynamics.  3 lectures.\n',
-          addl: 'Term Typically Offered: F, W\nPrerequisite: CHEM 126 or CHEM 129; MATH 143; PHYS 122 or PHYS 132 or PHYS 142.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM448',
-          catalog: '2022-2026',
-          displayName: 'Polymers and Coatings Laboratory II',
-          units: '2',
-          desc: 'Polymer synthesis using solution, suspension, bulk, emulsion techniques.  Synthesis of chain growth polymers using free radical, anionic, cationic, and other catalysts.  Synthesis of step-growth polymers.  Kinetics of polymer reactions.  Synthesis of resins used in modern coatings.  2 laboratories.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: CHEM 447. Corequisite: CHEM 445.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM445',
-          catalog: '2022-2026',
-          displayName: 'Polymers & Coatings II',
-          units: '3',
-          desc: 'Introduction to polymerization methods and mechanisms.  Chemistry of initiators, catalysts and inhibitors, kinetics of polymerization.  Uses of representative polymer types.  Synthesis, film formation, structure and properties of polymers commonly used in coatings and adhesives.  3 lectures.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: CHEM 217/317 and CHEM 444.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM475',
-          catalog: '2022-2026',
-          displayName: 'Molecular Biology Laboratory',
-          units: '3',
-          desc: 'Introduction to techniques used in molecular biology and biotechnology; DNA extraction, characterization, cloning, Southern blotting, reverse transcription, polymerase chain reaction, and sequencing analysis.  1 lecture, 2 laboratories.  Crosslisted as BIO/CHEM 475.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: BIO 161, and grade of C- or better in BIO 351 or CHEM 373 or consent of instructor.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM352',
-          catalog: '2022-2026',
-          displayName: 'Physical Chemistry II',
-          units: '3',
-          desc: 'Application of physical chemistry to chemical and biochemical systems.  Electrochemistry, kinetics, viscosity, surface and transport properties.  3 lectures.\n',
-          addl: 'Term Typically Offered: W, SP\nPrerequisite: CHEM 351.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM451',
-          catalog: '2022-2026',
-          displayName: 'Polymers and Coatings Laboratory III',
-          units: '2',
-          desc: 'Preparation and characterization of coatings - solvent based and waterborne.  Thermoplastic and thermosetting coatings.  Coating film preparation methods.  Applications of spectroscopy, scanning probe microscopy, thermal analysis, rheology in characterizing coatings.  VOC, long-term exposure testing.  Measurement of appearance (color, gloss).  Not open to students with credit in CHEM 551.  2 laboratories.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: CHEM 447 or CHEM 547. Corequisite: CHEM 450. Recommended: CHEM 445 or CHEM 545; CHEM 448 or CHEM 548; CHEM 446.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM450',
-          catalog: '2022-2026',
-          displayName: 'Polymers and Coatings III',
-          units: '3',
-          desc: "Formulation of modern coatings.  Raw materials including resins, solvents, pigments, and additives.  Formulation principles for solvent-borne and coatings, waterborne, powder, radiation cure and architectural coatings.  Regulatory issues; VOC's.  Coating properties, film formation, film defects, application methods, color and color acceptance.  Not open to students with credit in CHEM 550.  3 lectures.\n",
-          addl: 'Term Typically Offered: SP\nPrerequisite: CHEM 444 or CHEM 544.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM446',
-          catalog: '2022-2026',
-          displayName: 'Surface Chemistry of Materials',
-          units: '3',
-          desc: 'Surface energy.  Capillarity, solid and liquid interface, adsorption.  Surface areas of solids.  Contact angles and wetting.  Friction, lubrication and adhesion.  Relationship of surface to bulk properties of materials.  Applications.  3 lectures.  Crosslisted as CHEM/MATE 446.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: CHEM 125 or CHEM 128; CHEM 351, MATE 380, or ME 302.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM403',
-          catalog: '2022-2026',
-          displayName: 'Undergraduate Seminar III: Senior Project',
-          units: '1',
-          desc: 'Culminating experience with high level scientific literature and scientific presentation skills.  Targeted advising and preparation for research and career opportunities.  Designed for fourth-year CHEM and BCHM majors.  1 seminar.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: CHEM 303 and CHEM 352.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM353',
-          catalog: '2022-2026',
-          displayName: 'Physical Chemistry III',
-          units: '3',
-          desc: 'Principles and applications of quantum chemistry.  Chemical bonding and molecular structure.  Spectroscopy and diffraction.  3 lectures.\n',
-          addl: 'Term Typically Offered: F, SP\nPrerequisite: CHEM 352.\n',
-          gwrCourse: false,
-          uscpCourse: false
-        },
-        {
-          id: 'CHEM356',
-          catalog: '2022-2026',
-          displayName: 'Physical Chemistry Laboratory',
-          units: '2',
-          desc: 'Experimental studies of gases, solutions, thermochemistry, chemical and phase equilibria, electrochemistry, chemical and enzyme kinetics, computational methods and applications to chemistry and biochemistry.  Written communication of scientific results using applicable literature and databases.  2 laboratories.  Fulfills GWR.\n',
-          addl: 'Term Typically Offered: F, W, SP\nGWR\nPrerequisite: Junior standing; completion of GE Area A with grades of C- or better; and CHEM 231/331. Corequisite: CHEM 352.\n',
-          gwrCourse: true,
-          uscpCourse: false
-        }
-      ]
-    }
-  ]
-    // sort to ensure order of items doesn't matter in cache
-    .map((cache) => {
-      return {
-        catalog: cache.catalog,
-        courses: cache.courses.sort((a, b) => a.id.localeCompare(b.id))
-      };
-    })
-    .sort((a, b) => a.catalog.localeCompare(b.catalog))
+  courseCache: new Map([
+    [
+      '2015-2017',
+      new ObjectSet<APICourseFull>(
+        (crs) => crs.id,
+        [
+          {
+            id: 'AERO121',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Fundamentals',
+            units: '2',
+            desc: 'Introduction to the engineering profession including the aeronautical and aerospace fields. Engineering approach to problem-solving and analysis of data obtained from experiments. Basic nomenclature and design criteria used in the aerospace industry. Applications to basic problems in the field. 1 lecture, 1 laboratory.\n',
+            addl: 'Term Typically Offered: F\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATH141',
+            catalog: '2015-2017',
+            displayName: 'Calculus I',
+            units: '4',
+            desc: 'Limits, continuity, differentiation.  Introduction to integration.  4 lectures.  Crosslisted as HNRS/MATH 141.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
+            addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Completion of ELM requirement and passing score on appropriate Mathematics Placement Examination, or MATH 118 and high school trigonometry, or MATH 119.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'IME144',
+            catalog: '2015-2017',
+            displayName: 'Introduction to Design and Manufacturing',
+            units: '4',
+            desc: 'Supplemental review of visualization, sketching, and drafting fundamentals.  Computer-aided solid modeling of parts and assemblies.  Introduction to conventional machining processes on lathes and mills, computer numerical control, quality control, production methods, and design for manufacturing.  Open to all majors.  2 lectures, 2 laboratories.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nRecommended: IME 140 or ME 129 (Formerly ME 151).\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ENGL134',
+            catalog: '2015-2017',
+            displayName: 'Writing and Rhetoric',
+            units: '4',
+            desc: 'Rhetorical principles and tactics applied to written work.  Writing as a recursive process that leads to greater organizational coherency, stylistic complexity, and rhetorical awareness.  4 lectures.  Fulfills GE A1; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A1.\n',
+            addl: 'GE Area A1\nTerm Typically Offered: F, W, SP\nPrerequisite: Satisfactory score on the English Placement Test.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM124',
+            catalog: '2015-2017',
+            displayName: 'General Chemistry for Physical Science and Engineering I',
+            units: '4',
+            desc: 'Stoichiometry, thermochemistry, atomic structure, bonding, solid-state structures, intermolecular forces, and foundational principles of organic chemistry.  Not open to students with credit in CHEM 127.  Credit will be granted in only one of the following courses:  CHEM 110, CHEM 111, CHEM 124.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
+            addl: 'GE Area B4; GE Area B3\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Passing score on ELM, or an ELM exemption, or credit in MATH 104. Recommended: High school chemistry or equivalent.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATH142',
+            catalog: '2015-2017',
+            displayName: 'Calculus II',
+            units: '4',
+            desc: 'Techniques of integration, applications to physics, transcendental functions.  4 lectures.  Crosslisted as HNRS/MATH 142.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
+            addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 141 with a grade of C- or better or consent of instructor.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'COMS101',
+            catalog: '2015-2017',
+            displayName: 'Public Speaking',
+            units: '4',
+            desc: 'Introduction to the principles of public speaking. Practical experience in the development, presentation, and critical analysis of speeches to inform, to persuade, and to actuate. Not open to students with credit in COMS 102. 4 lectures. Crosslisted as COMS/HNRS 101. Fulfills GE A2; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A2.\n',
+            addl: 'GE Area A2\nTerm Typically Offered: F,W,SP,SU\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'PHYS132',
+            catalog: '2015-2017',
+            displayName: 'General Physics II',
+            units: '4',
+            desc: 'Oscillations, waves in elastic media, sound waves.  Temperature, heat and the first law of thermodynamics.  Kinetic theory of matter, second law of thermodynamics.  Geometrical and physical optics.  3 lectures, 1 laboratory.  Crosslisted as HNRS/PHYS 132.  Fulfills GE B3 & B4.\n',
+            addl: 'GE Area B3; GE Area B4\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: PHYS 131 or HNRS 131 or PHYS 141.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATH143',
+            catalog: '2015-2017',
+            displayName: 'Calculus III',
+            units: '4',
+            desc: 'Infinite sequences and series, vector algebra, curves.  4 lectures.  Crosslisted as HNRS/MATH 143.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
+            addl: 'GE Area B1\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142 with a grade of C- or better or consent of instructor.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ENGL149',
+            catalog: '2015-2017',
+            displayName: 'Technical Writing for Engineers',
+            units: '4',
+            desc: 'The principles of technical writing.  Discussion and application of rhetorical principles in technical environments.  Study of methods, resources and common formats used in corporate or research writing.  4 lectures.  Crosslisted as ENGL/HNRS 149.  Fulfills GE A3; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A3.\n',
+            addl: 'GE Area A3\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: Completion of GE Area A1 with a C- or better, or consent of instructor; for Engineering students only. Recommended: Completion of GE Area A2.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO215',
+            catalog: '2015-2017',
+            displayName: 'Introduction to Aerospace Design',
+            units: '2',
+            desc: 'Introduction to problem solving techniques and team-centered design projects in aerospace engineering.  Primary emphasis on the solutions of design problems in aerospace engineering using computers.  2 laboratories.\n',
+            addl: 'Term Typically Offered: F, W\nPrerequisite: AERO 121, MATH 143, and IME 144. Recommended: CSC 111.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATH241',
+            catalog: '2015-2017',
+            displayName: 'Calculus IV',
+            units: '4',
+            desc: 'Partial derivatives, multiple integrals, introduction to vector analysis.  4 lectures.  Crosslisted as HNRS/MATH 241.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 143.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ME211',
+            catalog: '2015-2017',
+            displayName: 'Engineering Statics',
+            units: '3',
+            desc: 'Analysis of forces on engineering structures in equilibrium.  Properties of forces, moments, couples, and resultants.  Equilibrium conditions, friction, centroids, area moments of inertia.  Introduction to mathematical modeling and problem solving.  Vector mathematics where appropriate.  3 lectures.  Crosslisted as HNRS/ME 211.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: MATH 241 (or concurrently), PHYS 131 or PHYS 141.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'PHYS133',
+            catalog: '2015-2017',
+            displayName: 'General Physics III',
+            units: '4',
+            desc: 'Charge and matter, electric field, electric potential, dielectrics, capacitance, current and resistance, electromotive force and circuits, magnetic fields, magnetic field of a moving charge, induced emf.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
+            addl: 'GE Area B3; GE Area B4\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: PHYS 131 or HNRS 131 or PHYS 141, and MATH 142. Recommended: MATH 241.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'BIO213',
+            catalog: '2015-2017',
+            displayName: 'Life Science for Engineers',
+            units: '2',
+            desc: 'Fundamentals of life sciences:  energetics, cell biology, molecular and classical genetics, microbiology, organismal biology, and ecology.  2 lectures.  Fulfills GE B2.\n',
+            addl: 'GE Area B2\nTerm Typically Offered: F, W, SP\nPrerequisite: MATH 142; for engineering students only. Corequisite: BMED/BRAE 213. Recommended: CHEM 124.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'BMED213',
+            catalog: '2015-2017',
+            displayName: 'Bioengineering Fundamentals',
+            units: '2',
+            desc: 'Treatment of the engineering applications of biology.  Genetic engineering and the industrial application of microbiology.  Systems physiology with engineering applications.  Structure and function relationships in biological systems.  The impact of life on its environment.  2 lectures.  Crosslisted as BRAE/BMED 213.  Fulfills GE B2.  Formerly BRAE/ENGR 213.\n',
+            addl: 'GE Area B2\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142; for engineering students only. Corequisite: BIO 213. Recommended: CHEM 124.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATE210',
+            catalog: '2015-2017',
+            displayName: 'Materials Engineering',
+            units: '3',
+            desc: 'Structure of matter.  Physical and mechanical properties of materials including metals, polymers, ceramics, composites, and electronic materials.  Equilibrium diagrams.  Heat treatments, materials selection and corrosion phenomena.  3 lectures.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: CHEM 111 or CHEM 124 or CHEM 127. Recommended: Concurrent enrollment in MATE 215.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ME212',
+            catalog: '2015-2017',
+            displayName: 'Engineering Dynamics',
+            units: '3',
+            desc: 'Analysis of motions of particles and rigid bodies encountered in engineering.  Velocity, acceleration, relative motion, work, energy, impulse, and momentum.  Further development of mathematical modeling and problem solving.  Vector mathematics where appropriate.  3 lectures.  Crosslisted as HNRS 214/ME 212.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: MATH 241; ME 211 or ARCE 211.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATH244',
+            catalog: '2015-2017',
+            displayName: 'Linear Analysis I',
+            units: '4',
+            desc: 'Separable and linear ordinary differential equations with selected applications; numerical and analytical solutions.  Linear algebra:  vectors in n-space, matrices, linear transformations, eigenvalues, eigenvectors, diagonalization; applications to the study of systems of linear differential equations.  4 lectures.  Crosslisted as HNRS/MATH 244.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 143.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CE204',
+            catalog: '2015-2017',
+            displayName: 'Mechanics of Materials I',
+            units: '3',
+            desc: 'Stresses, strains, and deformations associated with axial, torsional, and flexural loading of bars, shafts, and beams.  Analysis of elementary determinate and indeterminate mechanical and structural systems.  2 lectures, 1 activity.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: ME 211.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO301',
+            catalog: '2015-2017',
+            displayName: 'Aerothermodynamics I',
+            units: '4',
+            desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: ME 211. Corequisite: AERO 300.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO300',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Engineering Analysis',
+            units: '5',
+            desc: 'Analytical methods for aerospace engineering problems.  Topics include vector calculus, linear algebra, differential equations, Laplace transforms and Fourier series.  Computer tools and numerical methods as applied to problems in aerodynamics, structures, stability and control and astronautics.  4 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: AERO 215, MATH 244, ME 211, and PHYS 133.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'STAT312',
+            catalog: '2015-2017',
+            displayName: 'Statistical Methods for Engineers',
+            units: '4',
+            desc: 'Descriptive and graphical methods.  Discrete and continuous probability distributions.  One and two sample confidence intervals and hypothesis testing.  Single factor analysis of variance.  Quality control.  Introduction to regression and to experimental design.  Substantial use of statistical software.  4 lectures.  Fulfills GE B6.\n',
+            addl: 'GE Area B6\nTerm Typically Offered: F,W,SP,SU\nPrerequisite: MATH 142.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CE207',
+            catalog: '2015-2017',
+            displayName: 'Mechanics of Materials II',
+            units: '2',
+            desc: 'Combined stress states including torsion, axial, shear, moment, and pressure vessel loadings.  Principle stress/strain states.  Basic failure criteria.  Analysis of beam forces, moments, deflections, and rotations.  Introduction to stability concepts including column buckling.  1 lecture, 1 activity.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: CE 204.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO302',
+            catalog: '2015-2017',
+            displayName: 'Aerothermodynamics II',
+            units: '4',
+            desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: AERO 301.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO306',
+            catalog: '2015-2017',
+            displayName: 'Aerodynamics and Flight Performance',
+            units: '4',
+            desc: 'Introduction to theoretical aerodynamics.  Primary emphasis in the subsonic region, including compressibility effects.  Basic aerodynamic theory:  Airfoil theory, wing theory, lift and drag.  Team-centered aerodynamic design.  Flight performance.  4 lectures.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: AERO 215, AERO 301. Concurrent: AERO 302.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'EE201',
+            catalog: '2015-2017',
+            displayName: 'Electric Circuit Theory',
+            units: '3',
+            desc: 'Application of fundamental circuit laws and theorems to the analysis of DC, and steady-state single-phase and three-phase circuits.  Not for electrical engineering majors.  3 lectures.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: MATH 244, PHYS 133.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'EE251',
+            catalog: '2015-2017',
+            displayName: 'Electric Circuits Laboratory',
+            units: '1',
+            desc: 'Techniques of measurement of DC and steady-state AC circuit parameters.  Equivalent circuits, nonlinear elements, resonance.  1 laboratory.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nConcurrent: EE 201.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO320',
+            catalog: '2015-2017',
+            displayName: 'Fundamentals of Dynamics and Control',
+            units: '4',
+            desc: 'Introduction to six degree of freedom rigid body dynamic and kinematic equations of motion, including coordinate transformations, Euler angles and quaternions for aerospace vehicles.  Linearization and dynamic system theory and stability.  Introduction to linear control theory, controller design and analysis.  4 lectures.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: AERO 300 and ME 212.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO303',
+            catalog: '2015-2017',
+            displayName: 'Aerothermodynamics III',
+            units: '4',
+            desc: 'Properties and characteristics of fluids, fluid statics and dynamics, the thermodynamic relations, laminar and turbulent flows, subsonic and supersonic flows as applied to flight vehicles.  Introduction to heat transfer.  4 lectures.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: AERO 302.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO304',
+            catalog: '2015-2017',
+            displayName: 'Experimental Aerothermodynamics',
+            units: '2',
+            desc: 'Laboratory experiments verify the momentum and energy equations.  Mass flow rate, fan performance, boundary layer measurements, diffuser performance, and induction pump performance experiments are evaluated.  Introduction to electronic sensors, signals and data acquisition.  1 lecture, 1 laboratory.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: ENGL 149 and AERO 301.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO331',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Structural Analysis I',
+            units: '4',
+            desc: "Deflection analysis.  Principles of fictitious displacement, virtual work, and unit load method.  Energy methods:  Castigliano's theorem, Maxwell-Betti reciprocal theorem, minimum principles, Rayleigh-Ritz's method and Galerkin's method.  Stress analysis of aircraft and spacecraft components.  4 lectures.\n",
+            addl: 'Term Typically Offered: W\nPrerequisite: AERO 300, CE 207, and ME 212.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO420',
+            catalog: '2015-2017',
+            displayName: 'Aircraft Dynamics and Control',
+            units: '4',
+            desc: "Newton's 6-degree-of-freedom equations of motion applied to aerospace vehicles.  Stability and control derivatives, reference frames, steady-state and perturbed dynamic analyses applied to aerospace vehicles.  Stability and control design principles applied to transfer functions, state-space, and modal system dynamics.  4 lectures.\n",
+            addl: 'Term Typically Offered: W\nPrerequisite: AERO 306 and AERO 320.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO307',
+            catalog: '2015-2017',
+            displayName: 'Experimental Aerodynamics',
+            units: '2',
+            desc: 'Wind tunnel testing of basic aerodynamic properties of airfoils, finite wings, aircraft or spacecraft models, and vehicle flight performance.  Emphasis on both static and dynamic responses of aircraft.  Various measurement techniques, data reduction schemes, and analysis methods.  2 laboratories.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: AERO 302, AERO 306, ENGL 149.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO405',
+            catalog: '2015-2017',
+            displayName: 'Supersonic and Hypersonic Aerodynamics',
+            units: '4',
+            desc: 'Review of gas dynamics, shock-wave and boundary-layer interaction, aerodynamic design.  2-dimensional supersonic flows around thin airfoil; finite wing in supersonic flow.  Local surface inclination methods for high-speed flight, boundary-layer and aerodynamic heating, viscous interactions.  4 lectures.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: AERO 303; and AERO 306 or AERO 353.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO431',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Structural Analysis II',
+            units: '4',
+            desc: 'Basic equations of elasticity with applications to typical aerospace structures.  Concepts studied include analysis of aircraft and aerospace structures; airworthiness and airframe loads; structural constraints; elementary aeroelasticity; structural instability; introduction to modern fatigue; fracture mechanics; and composite structures analysis.  4 lectures.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: AERO 331.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO401',
+            catalog: '2015-2017',
+            displayName: 'Propulsion Systems',
+            units: '5',
+            desc: 'Power plant types, components, characteristics, and requirements.  Principles of thrust and energy utilization.  Thermodynamic processes and performance of turboprop, turboshaft, turbofan, turbojet, ramjet, and rocket engines.  4 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: AERO 303, CHEM 124.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO443',
+            catalog: '2015-2017',
+            displayName: 'Aircraft Design I',
+            units: '4',
+            desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  2 lectures, 2 laboratories.  Open to students enrolled in the multidisciplinary design minor.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: Senior standing, IME 144, AERO 215, AERO 303, AERO 306, AERO 331, AERO 405, AERO 420, AERO 431. Concurrent: AERO 401.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO433',
+            catalog: '2015-2017',
+            displayName: 'Experimental Stress Analysis',
+            units: '1',
+            desc: 'Employing the knowledge of stress analysis and aerospace structural analysis in an individual and group design project dealing with aerospace structures.  1 laboratory.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AERO 331, AERO 431.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO460',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Engineering Professional Preparation',
+            units: '1',
+            desc: 'Topics on professional development for student success including resume building and career prospecting, current events in the aerospace industry, graduate studies, engineering ethics, intellectual property, non-disclosure agreements, teamwork, and innovation and entrepreneurship.  1 activity.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: Senior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO444',
+            catalog: '2015-2017',
+            displayName: 'Aircraft Design II',
+            units: '3',
+            desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  3 laboratories.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: AERO 443 and senior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO465',
+            catalog: '2015-2017',
+            displayName: 'Aerospace Systems Senior Laboratory',
+            units: '1',
+            desc: 'Culminating laboratory based experience.  Experiments require the integration of the many disciplines in Aerospace Engineering.  The successful completion of each experiment requires synthesis and integration of the fundamental concepts of the engineering sciences.  Experimentation in the areas of aeroelasticity, active vibration control, inertial navigation, thermal control, hardware-in-the-loop simulation, and momentum exchange.  1 laboratory.\n',
+            addl: 'Term Typically Offered: F, W\nPrerequisite: AERO 303, AERO 304, AERO 320, AERO 431 and Senior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AERO445',
+            catalog: '2015-2017',
+            displayName: 'Aircraft Design III',
+            units: '3',
+            desc: 'Preliminary layout of a typical aircraft vehicle using design and calculation techniques developed in previous aerospace engineering courses.  Design of a flight vehicle, including its structures and systems.  Preparation of necessary drawings and a report.  3 laboratories.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: AERO 444 and senior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          }
+        ]
+      )
+    ],
+    [
+      '2022-2026',
+      new ObjectSet<APICourseFull>(
+        (crs) => crs.id,
+        [
+          {
+            id: 'CHEM125',
+            catalog: '2022-2026',
+            displayName: 'General Chemistry for Physical Science and Engineering II',
+            units: '4',
+            desc: 'Topics include solution chemistry, thermodynamics, kinetics, equilibrium (including acids and bases), electrochemistry, and nuclear chemistry.  Not open to students with credit in CHEM 128.  3 lectures, 1 laboratory.  Fulfills GE Areas B1 and B3 (GE Areas B3 and B4 for students on the 2019-20 or earlier catalogs).\n',
+            addl: 'Term Typically Offered: F, W, SP\n2020-21 or later catalog: GE Area B1\n2020-21 or later catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B4\nPrerequisite: CHEM 124, or AP Chemistry score of 5.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'BIO161',
+            catalog: '2022-2026',
+            displayName: 'Introduction to Cell and Molecular Biology',
+            units: '4',
+            desc: 'Fundamentals of cellular biology with an emphasis on the molecular perspective of life:  biomolecules, cellular energetics, cell structure and reproduction, molecular mechanisms of genetics and gene expression.  3 lectures, 1 laboratory.  Fulfills GE Areas B2 and B3 (GE Areas B2 and B4 for students on the 2019-20 or earlier catalogs).\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\n2020-21 or later catalog: GE Area B2\n2020-21 or later catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B2\n2019-20 or earlier catalog: GE Area B4\nRecommended: CHEM 110 or CHEM 124 or CHEM 127.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM126',
+            catalog: '2022-2026',
+            displayName: 'General Chemistry for Physical Science and Engineering III',
+            units: '4',
+            desc: 'Topics in equilibrium, kinetics, acid-base chemistry, and molecular structure, contextualized within major sub-disciplines of chemistry.  Not open to students with credit in CHEM 129.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: CHEM 125 with a grade of C- or better or consent of instructor.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'PHYS141',
+            catalog: '2022-2026',
+            displayName: 'General Physics I',
+            units: '4',
+            desc: 'Fundamental principles of mechanics.  Vectors, particle kinematics.  Equilibrium of a rigid body.  Work and energy, linear momentum, rotational kinematics and dynamics.  Primarily for engineering and science students.  Course may be offered in classroom-based or online format.  4 lectures.  Crosslisted as HNRS 134/PHYS 141.  Fulfills GE Area B1 (GE Area B3 for students on the 2019-20 or earlier catalogs).\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\n2020-21 or later catalog: GE Area B1\n2019-20 or earlier catalog: GE Area B3\nPrerequisite: MATH 141 with grade C- or better. Corequisite: MATH 142 or MATH 182. Recommended: High School Physics.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'COMS126',
+            catalog: '2022-2026',
+            displayName: 'Argument and Advocacy',
+            units: '4',
+            desc: 'The nature of critical thinking as applied in oral and written argument.  Study of inductive and deductive reasoning.  Analysis of reasoning, argument, forms of support and fallacies of argument and language.  Instruction in and practical experience in crafting sound persuasive arguments and engaging in oral argumentation.  Course may be offered in classroom-based or hybrid format.  4 lectures.   Fulfills GE Area A3 with a grade of C- or better.\n',
+            addl: 'Term Typically Offered: F\n2020-21 or later catalog: GE Area A3\n2019-20 or earlier catalog: GE Area A3\nPrerequisite: Completion of GE Area A2 with a grade of C- or better (GE Area A1 for student on the 2019-20 or an earlier catalog). Recommended: Completion of GE Area A1 with a grade of C- or better (GE Area A2 for student on the 2019-20 or an earlier catalog).\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM216',
+            catalog: '2022-2026',
+            displayName: 'Organic Chemistry I',
+            units: '5',
+            desc: 'Fundamental concepts and laboratory skills of organic chemistry.  Structure, bonding, nomenclature, isomerism, stereochemistry and physical properties of organic compounds.  Introduction to spectroscopy.  Reactions and mechanisms of alkanes, alkenes and alkyl halides.  Fundamental laboratory techniques in organic chemistry.  Not open to students with credit in CHEM 316.  4 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: F, W\nPrerequisite: CHEM 126 or CHEM 129 with a grade of C- or better or consent of instructor.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM331',
+            catalog: '2022-2026',
+            displayName: 'Quantitative Analysis',
+            units: '5',
+            desc: 'Theory and application of chemical equilibrium to analytical problems.  Survey of important analytical methods with stress placed on the theory and application associated with titrimetric and spectrophotometric analysis.  3 lectures, 2 laboratories.\n',
+            addl: 'Term Typically Offered: F, SP, SU\nPrerequisite: CHEM 126 or CHEM 129.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'PHYS142',
+            catalog: '2022-2026',
+            displayName: 'General Physics II',
+            units: '4',
+            desc: 'Oscillations, waves in elastic media, sound waves.  Temperature, heat and the first law of thermodynamics.  Kinetic theory of matter, second law of thermodynamics.  Geometrical and physical optics.  3 lectures, 1 laboratory.  Crosslisted as HNRS 132/PHYS 142.  Fulfills GE Areas B1 and B3 (GE Areas B3 and B4 for students on the 2019-20 or earlier catalogs).  Formerly PHYS 132.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\n2020-21 or later catalog: GE Area B1\n2020-21 or later catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B4\nPrerequisite: PHYS 141; and MATH 142 or MATH 182.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM203',
+            catalog: '2022-2026',
+            displayName: 'Undergraduate Seminar I',
+            units: '1',
+            desc: 'Introduction to basic scientific literature and scientific presentation skills.  Targeted advising and preparation for research and career opportunities.  Designed for second-year students majoring in Biochemistry or in Chemistry.  Credit/No Credit grading only.  1 seminar.\n',
+            addl: 'Term Typically Offered: W, SP\nCR/NC\nPrerequisite: CHEM 126.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM217',
+            catalog: '2022-2026',
+            displayName: 'Organic Chemistry II',
+            units: '3',
+            desc: 'Properties and reactions of carbonyl compounds, alcohols, ethers, amines and carbohydrates with an in-depth treatment of the reaction mechanisms.  Introductory concepts and applications of infrared and NMR spectroscopy.  Not open to students with credit in CHEM 317.  3 lectures.\n',
+            addl: 'Term Typically Offered: W, SP\nPrerequisite: CHEM 216 with a grade of C- or better or consent of instructor. Corequisite: CHEM 221 for Chemistry and Biochemistry majors; or CHEM 220 for non-Chemistry and non-Biochemistry majors.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM221',
+            catalog: '2022-2026',
+            displayName: 'Organic Chemistry Laboratory II',
+            units: '2',
+            desc: 'Laboratory experiments exploring reactions in organic chemistry, applying fundamental laboratory techniques covered in CHEM 216.  2 laboratories.\n',
+            addl: 'Term Typically Offered: W, SP\nPrerequisite: major in Chemistry or Biochemistry. Corequisite: CHEM 217.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'PHYS143',
+            catalog: '2022-2026',
+            displayName: 'General Physics III',
+            units: '4',
+            desc: 'Charge and matter, electric field, electric potential, dielectrics, capacitance, current and resistance, electromotive force and circuits, magnetic fields, magnetic field of a moving charge, induced emf.  3 lectures, 1 laboratory.  Fulfills GE Areas B1 and B3 (GE Areas B3 and B4 for students on the 2019-20 or earlier catalogs).  Formerly PHYS 133.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\n2020-21 or later catalog: GE Area B1\n2020-21 or later catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B3\n2019-20 or earlier catalog: GE Area B4\nPrerequisite: MATH 142 and PHYS 141. Recommended: MATH 241.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM218',
+            catalog: '2022-2026',
+            displayName: 'Organic Chemistry III',
+            units: '3',
+            desc: 'Properties and reactions of alkynes, heterocyclic and aromatic compounds with an in-depth treatment of the mechanisms of the reactions.  Introductory concepts and applications of ultraviolet spectroscopy and mass spectrometry.  Not open to students with credit in CHEM 318.  3 lectures.\n',
+            addl: 'Term Typically Offered: F, SP\nPrerequisite: CHEM 217 with a grade of C- or better or consent of instructor. Corequisite: CHEM 324 for Chemistry and Biochemistry majors; or CHEM 223 for non-Chemistry and non-Biochemistry majors.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM324',
+            catalog: '2022-2026',
+            displayName: 'Organic Chemistry Laboratory III',
+            units: '2',
+            desc: 'Practice in multiple step organic synthesis, column chromatography, vacuum distillation, enzymes as chemical reagents, inert atmosphere techniques, introduction to FT NMR spectroscopy and mass spectrometry, survey of organic chemical literature.  2 laboratories.\n',
+            addl: 'Term Typically Offered: F, SP\nPrerequisite: major in Chemistry or Biochemistry. Corequisite: CHEM 218.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM369',
+            catalog: '2022-2026',
+            displayName: 'Biochemical Principles',
+            units: '5',
+            desc: 'Chemistry and function of major cellular constituents:  proteins, lipids, carbohydrates, nucleic acids, and membranes.  Mechanisms of protein function and regulation and enzyme catalysis.  4 lectures, 1 laboratory.   Fulfills GE Area Upper-Division B (GE Areas B5, B6, or B7 for students on the 2019-20 catalog).\n',
+            addl: 'Term Typically Offered: F, W, SP\n2020-21 or later: Upper-Div GE Area B\n2019-20 or earlier catalog: GE Area B5, B6, or B7\nPrerequisite: Junior standing; completion of GE Area A with grades C- or better; completion of GE Area B1 (GE Area B3 for students on the 2019-20 or earlier catalogs); one course in GE Area B4 with a grade of C- or better (GE Area B1 for students on the 2019-20 or earlier catalogs); BIO 161; and CHEM 217 or CHEM 317.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM303',
+            catalog: '2022-2026',
+            displayName: 'Undergraduate Seminar II',
+            units: '1',
+            desc: 'Advanced exploration of more sophisticated scientific literature and scientific presentation skills.  Targeted advising and preparation for research and career opportunities.  Designed for third-year CHEM and BCHM majors.  Credit/No Credit grading only.  1 seminar.\n',
+            addl: 'Term Typically Offered: F, W, SP\nCR/NC\nPrerequisite: CHEM 203 and CHEM 218.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM372',
+            catalog: '2022-2026',
+            displayName: 'Metabolism',
+            units: '4',
+            desc: 'Intermediary metabolism of carbohydrates, lipids, amino acids and nucleotides, regulation and integration of metabolic pathways, bioenergetics, photosynthesis, electron transport, nitrogen fixation, biochemical function of vitamins and minerals.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, SP\nPrerequisite: CHEM 369 or CHEM 371.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM444',
+            catalog: '2022-2026',
+            displayName: 'Polymers & Coatings I',
+            units: '3',
+            desc: 'Physical properties of polymers and coatings and their measurement.  Molecular weight averages, glass transition, thermodynamics of polymers.  Viscoelastic properties, rheology, molecular weight determination.  Thermal analysis, spectroscopic analysis, mechanical testing.  3 lectures.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: CHEM 212/312 or CHEM 216/316.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM447',
+            catalog: '2022-2026',
+            displayName: 'Polymers and Coatings Laboratory I',
+            units: '2',
+            desc: 'Experimental techniques of producing and characterizing coatings.  Polymer characterization and analysis.  Molecular weight analysis using viscometry, light scattering, and gel permeation chromatography.  Thermal analysis using differential scanning calorimetry, thermal mechanical analysis and dynamic mechanical analysis.  Polymer rheology.  Infrared, Raman and FT-NMR spectroscopy.  Atomic force microscopy.  2 laboratories.\n',
+            addl: 'Term Typically Offered: F\nCorequisite: CHEM 444.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM373',
+            catalog: '2022-2026',
+            displayName: 'Molecular Biology',
+            units: '3',
+            desc: 'Structure of nucleic acids and chromosomes.  Mechanisms and regulation of nucleic acid and protein synthesis.  Molecular biology techniques.  3 lectures.\n',
+            addl: 'Term Typically Offered: W, SP\nPrerequisite: CHEM 369 or CHEM 371.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM351',
+            catalog: '2022-2026',
+            displayName: 'Physical Chemistry I',
+            units: '3',
+            desc: 'Basic physical chemistry for the study of chemical and biochemical systems.  Kinetic-molecular theory, gas laws, principles of thermodynamics.  3 lectures.\n',
+            addl: 'Term Typically Offered: F, W\nPrerequisite: CHEM 126 or CHEM 129; MATH 143; PHYS 122 or PHYS 132 or PHYS 142.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM448',
+            catalog: '2022-2026',
+            displayName: 'Polymers and Coatings Laboratory II',
+            units: '2',
+            desc: 'Polymer synthesis using solution, suspension, bulk, emulsion techniques.  Synthesis of chain growth polymers using free radical, anionic, cationic, and other catalysts.  Synthesis of step-growth polymers.  Kinetics of polymer reactions.  Synthesis of resins used in modern coatings.  2 laboratories.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: CHEM 447. Corequisite: CHEM 445.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM445',
+            catalog: '2022-2026',
+            displayName: 'Polymers & Coatings II',
+            units: '3',
+            desc: 'Introduction to polymerization methods and mechanisms.  Chemistry of initiators, catalysts and inhibitors, kinetics of polymerization.  Uses of representative polymer types.  Synthesis, film formation, structure and properties of polymers commonly used in coatings and adhesives.  3 lectures.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: CHEM 217/317 and CHEM 444.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM475',
+            catalog: '2022-2026',
+            displayName: 'Molecular Biology Laboratory',
+            units: '3',
+            desc: 'Introduction to techniques used in molecular biology and biotechnology; DNA extraction, characterization, cloning, Southern blotting, reverse transcription, polymerase chain reaction, and sequencing analysis.  1 lecture, 2 laboratories.  Crosslisted as BIO/CHEM 475.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: BIO 161, and grade of C- or better in BIO 351 or CHEM 373 or consent of instructor.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM352',
+            catalog: '2022-2026',
+            displayName: 'Physical Chemistry II',
+            units: '3',
+            desc: 'Application of physical chemistry to chemical and biochemical systems.  Electrochemistry, kinetics, viscosity, surface and transport properties.  3 lectures.\n',
+            addl: 'Term Typically Offered: W, SP\nPrerequisite: CHEM 351.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM451',
+            catalog: '2022-2026',
+            displayName: 'Polymers and Coatings Laboratory III',
+            units: '2',
+            desc: 'Preparation and characterization of coatings - solvent based and waterborne.  Thermoplastic and thermosetting coatings.  Coating film preparation methods.  Applications of spectroscopy, scanning probe microscopy, thermal analysis, rheology in characterizing coatings.  VOC, long-term exposure testing.  Measurement of appearance (color, gloss).  Not open to students with credit in CHEM 551.  2 laboratories.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: CHEM 447 or CHEM 547. Corequisite: CHEM 450. Recommended: CHEM 445 or CHEM 545; CHEM 448 or CHEM 548; CHEM 446.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM450',
+            catalog: '2022-2026',
+            displayName: 'Polymers and Coatings III',
+            units: '3',
+            desc: "Formulation of modern coatings.  Raw materials including resins, solvents, pigments, and additives.  Formulation principles for solvent-borne and coatings, waterborne, powder, radiation cure and architectural coatings.  Regulatory issues; VOC's.  Coating properties, film formation, film defects, application methods, color and color acceptance.  Not open to students with credit in CHEM 550.  3 lectures.\n",
+            addl: 'Term Typically Offered: SP\nPrerequisite: CHEM 444 or CHEM 544.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM446',
+            catalog: '2022-2026',
+            displayName: 'Surface Chemistry of Materials',
+            units: '3',
+            desc: 'Surface energy.  Capillarity, solid and liquid interface, adsorption.  Surface areas of solids.  Contact angles and wetting.  Friction, lubrication and adhesion.  Relationship of surface to bulk properties of materials.  Applications.  3 lectures.  Crosslisted as CHEM/MATE 446.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: CHEM 125 or CHEM 128; CHEM 351, MATE 380, or ME 302.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM403',
+            catalog: '2022-2026',
+            displayName: 'Undergraduate Seminar III: Senior Project',
+            units: '1',
+            desc: 'Culminating experience with high level scientific literature and scientific presentation skills.  Targeted advising and preparation for research and career opportunities.  Designed for fourth-year CHEM and BCHM majors.  1 seminar.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: CHEM 303 and CHEM 352.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM353',
+            catalog: '2022-2026',
+            displayName: 'Physical Chemistry III',
+            units: '3',
+            desc: 'Principles and applications of quantum chemistry.  Chemical bonding and molecular structure.  Spectroscopy and diffraction.  3 lectures.\n',
+            addl: 'Term Typically Offered: F, SP\nPrerequisite: CHEM 352.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM356',
+            catalog: '2022-2026',
+            displayName: 'Physical Chemistry Laboratory',
+            units: '2',
+            desc: 'Experimental studies of gases, solutions, thermochemistry, chemical and phase equilibria, electrochemistry, chemical and enzyme kinetics, computational methods and applications to chemistry and biochemistry.  Written communication of scientific results using applicable literature and databases.  2 laboratories.  Fulfills GWR.\n',
+            addl: 'Term Typically Offered: F, W, SP\nGWR\nPrerequisite: Junior standing; completion of GE Area A with grades of C- or better; and CHEM 231/331. Corequisite: CHEM 352.\n',
+            gwrCourse: true,
+            uscpCourse: false,
+            dynamicTerms: null
+          }
+        ]
+      )
+    ]
+  ])
 };
 
 export const responsePayload3 = {
@@ -3273,739 +3386,517 @@ export const responsePayload3 = {
     publishedId: null,
     importedId: null
   },
-  courseCache: [
-    {
-      catalog: '2015-2017',
-      courses: [
-        {
-          id: 'AGB101',
-          catalog: '2015-2017',
-          displayName: 'Introduction to Agribusiness',
-          units: '4',
-          desc: 'Orientation to the agribusiness sector of agriculture.  An overview of the breadth, size, scope and management aspects of the agricultural business complex.  Agribusiness students are required to complete this within the first year of the major.  4 lectures.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: AGB major and freshman standing.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: false,
-            termSpring: false
+  courseCache: new Map([
+    [
+      '2015-2017',
+      new ObjectSet<APICourseFull>(
+        (crs) => crs.id,
+        [
+          {
+            id: 'AGB101',
+            catalog: '2015-2017',
+            displayName: 'Introduction to Agribusiness',
+            units: '4',
+            desc: 'Orientation to the agribusiness sector of agriculture.  An overview of the breadth, size, scope and management aspects of the agricultural business complex.  Agribusiness students are required to complete this within the first year of the major.  4 lectures.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: AGB major and freshman standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB202',
+            catalog: '2015-2017',
+            displayName: 'Introduction to Sales',
+            units: '4',
+            desc: 'Development of professional business-to-business selling principles within the supply chain, including an introduction to understanding the sales process from different buying and selling perspectives, communication techniques, and basic sales competency. 4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB212',
+            catalog: '2015-2017',
+            displayName: 'Agricultural Economics',
+            units: '4',
+            desc: 'Theoretical development of factors affecting demand and supply for food and fiber and for agricultural inputs. Methods of selecting optimal levels of agricultural production and consumption variables. Evaluation of market structure and price formulation for agricultural products and resources. 4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB214',
+            catalog: '2015-2017',
+            displayName: 'Agribusiness Financial Accounting',
+            units: '4',
+            desc: 'Principles of financial accounting in agribusiness. Preparation for understanding and interpreting financial statements. Exploration of financial reporting standards to provide an understanding of how financial events are reflected in financial statements. The importance of social responsibility in accounting. The accounting cycle, from transactions posting to financial statements through spreadsheet applications. 3 lectures, 1 activity.\n',
+            addl: 'Term Typically Offered: F, W, SP\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB260',
+            catalog: '2015-2017',
+            displayName: 'Agribusiness Data Literacy',
+            units: '4',
+            desc: 'Using data and analysis in making decisions related to agribusiness.  Developing basic and intermediate spreadsheet skills necessary to organize, analyze, and summarize information.  Development of data management and analysis as tools to assist in agribusiness problem-solving.  4 lectures.\n',
+            addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: AGB 101 or junior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB301',
+            catalog: '2015-2017',
+            displayName: 'Food and Fiber Marketing',
+            units: '4',
+            desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB308',
+            catalog: '2015-2017',
+            displayName: 'Introduction to Agribusiness Finance',
+            units: '4',
+            desc: 'Concepts and analytical methods related to agricultural finance.  Focus on applied spreadsheet analysis of financial statements, time value of money, risk and return, portfolio theory, and capital budgeting within the context of financial institutions specific to agriculture.  Not open to students with credit in AGB 310.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 214 and AGB 260.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB312',
+            catalog: '2015-2017',
+            displayName: 'Agricultural Policy',
+            units: '4',
+            desc: 'Agricultural policy objectives and formulation, resource allocation and production adjustments.  Survey of State and Federal agricultural policies as they influence the planning and practices of agribusiness.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 and ECON 222.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB313',
+            catalog: '2015-2017',
+            displayName: 'Agriculture Economic Analysis',
+            units: '4',
+            desc: 'Advanced agricultural microeconomics with emphasis on mathematical problem solving; production and cost functions, single and multiple input allocation, agricultural output combinations, agricultural market structures, and economies of size.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 and MATH 221.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB323',
+            catalog: '2015-2017',
+            displayName: 'Agribusiness Managerial Accounting',
+            units: '4',
+            desc: 'Agribusiness management with an emphasis on using accounting procedures that will provide useful information in making management decisions, setting objectives, and controlling operations.  3 lectures, 1 activity.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 214.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB327',
+            catalog: '2015-2017',
+            displayName: 'Agribusiness Data Analysis',
+            units: '4',
+            desc: 'Methods in agricultural business data analysis, including multiple regression analysis, analysis of variance, and time series analysis.  Applications include agricultural price forecasting and estimation of the determinants of food and fiber demand.  3 lectures, 1 activity.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: STAT 251 and AGB 260.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB328',
+            catalog: '2015-2017',
+            displayName: 'Decision Tools for Agribusiness',
+            units: '4',
+            desc: 'Development of agribusiness modeling techniques that are applied to solving a diverse and unique set of resource allocation issues encountered throughout the agricultural and food retail sectors.  Techniques include linear programming, decision analysis, and computer simulations.  3 lectures, 1 activity.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: STAT 251 and AGB 260.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'AGB369',
+            catalog: '2015-2017',
+            displayName: 'Agricultural Personnel Management',
+            units: '4',
+            desc: 'Standard topics of California agricultural personnel management:  recruitment; appraisal and performance evaluation; compensation; training and development; discipline; safety and health; labor relations; and immigration policy.  Systemic approach to aspects of managing human capital, and how to implement human resource policies.  Not open to students with credit in AGB 401.  4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 201 or ECON 221; and junior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'BUS207',
+            catalog: '2015-2017',
+            displayName: 'Legal Responsibilities of Business',
+            units: '4',
+            desc: 'Examination of the American legal system and important legal principles for business operations, such as those involved with contracts, torts, agency, business organizations, and employment. Emphasis on how legal principles help define socially responsible conduct. Case studies. 4 lectures.\n',
+            addl: 'Term Typically Offered: F, W, SP\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'CHEM110',
+            catalog: '2015-2017',
+            displayName: 'World of Chemistry',
+            units: '4',
+            desc: 'The fundamentals of chemical cause and effect-structure/function relationships.  The basic principles of chemistry and their applications to solving human problems in organic materials science, biochemistry, toxicology, environmental science, agriculture, nutrition, and medicine.  Not open to students majoring in Chemistry or Biochemistry.  Not open to students with credit in CHEM 111, CHEM 124, or CHEM 127.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
+            addl: 'GE Area B3; GE Area B4\nTerm Typically Offered: F, W, SP\nPrerequisite: Passing score on ELM examination, or an ELM exemption, or MATH 104.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'COMS101',
+            catalog: '2015-2017',
+            displayName: 'Public Speaking',
+            units: '4',
+            desc: 'Introduction to the principles of public speaking. Practical experience in the development, presentation, and critical analysis of speeches to inform, to persuade, and to actuate. Not open to students with credit in COMS 102. 4 lectures. Crosslisted as COMS/HNRS 101. Fulfills GE A2; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A2.\n',
+            addl: 'GE Area A2\nTerm Typically Offered: F,W,SP,SU\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'COMS126',
+            catalog: '2015-2017',
+            displayName: 'Argument and Advocacy',
+            units: '4',
+            desc: 'The nature of critical thinking as applied in written and oral argument.  Analysis of inductive and deductive reasoning.  Analysis of reasoning, argument, forms of support and fallacies of argument and language.  Instruction in and practical experience in writing sound persuasive arguments and engaging in oral argumentation assignments.  4 lectures.  Fulfills GE A3; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A3.\n',
+            addl: 'GE Area A3\nTerm Typically Offered: W, SP\nPrerequisite: Completion of GE Area A1 with a C- or better, or consent of instructor. Recommended: Completion of GE Area A2.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ECON222',
+            catalog: '2015-2017',
+            displayName: 'Macroeconomics',
+            units: '4',
+            desc: 'Introduction to economic problems. Macroeconomic analysis and principles. Aggregate output, employment, prices, and economic policies for changing these variables. International trade and finance. Issues of economic growth and development. Comparative economic systems and economies in transition. 4 lectures. Fulfills GE D2.\n',
+            addl: 'GE Area D2\nTerm Typically Offered: F,W,SP,SU\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ENGL134',
+            catalog: '2015-2017',
+            displayName: 'Writing and Rhetoric',
+            units: '4',
+            desc: 'Rhetorical principles and tactics applied to written work.  Writing as a recursive process that leads to greater organizational coherency, stylistic complexity, and rhetorical awareness.  4 lectures.  Fulfills GE A1; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A1.\n',
+            addl: 'GE Area A1\nTerm Typically Offered: F, W, SP\nPrerequisite: Satisfactory score on the English Placement Test.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'MATH221',
+            catalog: '2015-2017',
+            displayName: 'Calculus for Business and Economics',
+            units: '4',
+            desc: 'Polynomial calculus for optimization and marginal analysis, and elementary integration.  Not open to students with credit in MATH 142.  4 lectures.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
+            addl: 'GE Area B1\nTerm Typically Offered: W, SP\nPrerequisite: Completion of ELM requirement and passing score on appropriate Mathematics Placement Examination, or MATH 118.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'STAT251',
+            catalog: '2015-2017',
+            displayName: 'Statistical Inference for Management I',
+            units: '4',
+            desc: 'Descriptive statistics.  Probability and counting rules.  Random variables and probability distributions.  Sampling distributions and point estimation.  Confidence intervals and tests of hypotheses for a single mean and proportion.  4 lectures.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
+            addl: 'GE Area B1\nTerm Typically Offered: F, W, SP\nPrerequisite: Completion of the ELM requirement and a passing score on appropriate Mathematics Placement Examination for MATH 221 eligibility, or MATH 118 or equivalent.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
           }
-        },
-        {
-          id: 'AGB202',
-          catalog: '2015-2017',
-          displayName: 'Introduction to Sales',
-          units: '4',
-          desc: 'Development of professional business-to-business selling principles within the supply chain, including an introduction to understanding the sales process from different buying and selling perspectives, communication techniques, and basic sales competency. 4 lectures.\n',
-          addl: 'Term Typically Offered: F, W, SP\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
+        ]
+      )
+    ],
+    [
+      '2017-2019',
+      new ObjectSet<APICourseFull>(
+        (crs) => crs.id,
+        [
+          {
+            id: 'ART101',
+            catalog: '2017-2019',
+            displayName: 'The Fundamentals of Drawing',
+            units: '4',
+            desc: 'Introduction to the artistic practice and cultural value of drawing from the Renaissance to the 21st Century. Emphasis and expansion of the practical skills of observation, rendering, and understanding the signs of meaning produced in visual art. Development of formal techniques, media experimentation, and content creation through personal expression. Exercises to encourage growth in technical skill, conceptual innovation, critical thinking, and visual communication. 3 lectures, 1 laboratory. Fulfills GE C3.\n',
+            addl: 'GE Area C3\nTerm Typically Offered: F, W, SP\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART102',
+            catalog: '2017-2019',
+            displayName: 'Art and Design Foundation Studies I',
+            units: '4',
+            desc: 'Introduces elements and principles of design, establishing a foundation for all artistic practice. Emphasizing critical thinking and creative problem solving, the interrelationship between form and content are examined. Traditional, digital and lens-based media are explored through individual and collaborative experiences. 3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: F\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART103',
+            catalog: '2017-2019',
+            displayName: 'Art and Design Foundation Studies II',
+            units: '4',
+            desc: 'Visual and aesthetic interactions of color, examined through historical and contemporary models.  Formal techniques, media experimentation and content creation, explored through individual and collaborative experiences.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: ART 102.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART104',
+            catalog: '2017-2019',
+            displayName: 'Art and Design Foundation Studies III',
+            units: '4',
+            desc: 'Principles and essential skills for three-dimensional practice in art and design.  Understanding, envisioning, and communicating effectively about space, objects, scale, and the relationship of the body to the built environment.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: ART 103.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART122',
+            catalog: '2017-2019',
+            displayName: 'Basic Digital Photography',
+            units: '4',
+            desc: 'Fundamental techniques in photography. Mechanics of digital cameras, optics, composition, perception of light and subject content. Understanding photographic principles and the language of camera vision. Introduction to the impact of photography on culture. Digital camera required. 3 lectures, 1 laboratory. Fulfills GE C3.\n',
+            addl: 'GE Area C3\nTerm Typically Offered: F, W, SP\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART182',
+            catalog: '2017-2019',
+            displayName: 'Foundation in Digital Art I',
+            units: '4',
+            desc: 'Introduction to image creation and manipulation, design, illustration, and layout/composition using digital tools, with an emphasis on visual problem solving and creative expression. 3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: F\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART203',
+            catalog: '2017-2019',
+            displayName: 'Art Theory and Practice',
+            units: '4',
+            desc: "Contemporary issues in art and design, linking 'ideas' to development of concepts.  Emphasis on individual creative process, and problem solving.  Focus on contemporary critical thinking regarding aesthetics, techniques, and vocabulary.  3 lectures, 1 laboratory.\n",
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: ART 101; and ART 102 or ART 106.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART209',
+            catalog: '2017-2019',
+            displayName: 'Beginning Painting',
+            units: '4',
+            desc: 'Introduction to technical and formal problems in painting.  Exploration of pictorial space, light, and color from observation.  Physical characteristics of paint, various tools, studio methods, and styles of painting.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: F, W, SP\nPrerequisite: ART 101.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART212',
+            catalog: '2017-2019',
+            displayName: 'Art History - Renaissance through Baroque Eras',
+            units: '4',
+            desc: 'The significant visual expressions of Northern and Southern European art of the Renaissance and Baroque period. Relevant parallel examples of the art of antiquity and non-European cultures. 4 lectures.\n',
+            addl: 'Term Typically Offered: W, SP\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART213',
+            catalog: '2017-2019',
+            displayName: 'Art History- Modern Art, 1900-1945',
+            units: '4',
+            desc: 'Examines the development of significant styles and movements in modern art, including Fauvism, German Expressionism, Cubism, Futurism, Neo-Plasticism, Russian and Soviet avant-gardes, Dada, Surrealism, and/or American modernism. Also introduces selected modern developments in graphic design and photography. 4 lectures. Replaces ART 312.\n',
+            addl: 'Term Typically Offered: F\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART222',
+            catalog: '2017-2019',
+            displayName: 'Black and White Photography',
+            units: '4',
+            desc: "Control and understanding of tonal range under available light. Composition, camera based visual communication skills and concept development. Emphasis on 'photographic seeing' and professional quality printing. 2 lectures, 2 laboratories.\n",
+            addl: 'Term Typically Offered: SP\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART224',
+            catalog: '2017-2019',
+            displayName: 'Introduction to Artificial Lighting for Photography',
+            units: '4',
+            desc: 'Introduction to studio lighting and contemporary professional studio photography. Production of professional quality prints using digital camera and printing methods. 3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: F, W, SP\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART260',
+            catalog: '2017-2019',
+            displayName: 'Critique, Discourse and Practice',
+            units: '4',
+            desc: 'Developing an individual body of artwork.  Rigorous critiques, lectures, and seminar-style discussions aimed at forming a process for discussing artwork.  Art writing, research, and individual conceptual and formal development.  4 lectures.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: ART 101 and ART 104.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART314',
+            catalog: '2017-2019',
+            displayName: 'History of Photography',
+            units: '4',
+            desc: 'In-depth survey of the artistic and cultural achievements in photography from its invention to the present day.  Significant photographers, the evolution of aesthetic criteria in the context of other visual arts as well as social/cultural impact.  4 lectures.  Fulfills GE C4 except for Art and Design majors.\n',
+            addl: 'GE Area C4\nTerm Typically Offered: W\nPrerequisite: Junior standing; completion of GE Area A with a grade of C- or better; and completion of GE Area C3.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART315',
+            catalog: '2017-2019',
+            displayName: 'Art History - Art Since 1945',
+            units: '4',
+            desc: 'History of visual art from 1945 to the present.  Focus on significant movements such as Abstract Expressionism, Pop art, minimalism, conceptual art, earthworks, feminism, and postmodernism.  Also focus on new mediums such as performance, video, and installation.  4 lectures.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: ART 112 or ART 211 or ART 212 or ART 213; and Junior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART324',
+            catalog: '2017-2019',
+            displayName: 'Photographic Expression',
+            units: '4',
+            desc: 'Emphasis on personal expression and developing style, introduction to symbology, visual source development and the work of contemporary creative photographers.  Total credit limited to 8 units.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: ART 122 or ART 224. Recommended: ART 222.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART325',
+            catalog: '2017-2019',
+            displayName: 'Advanced Camera and Lighting Techniques',
+            units: '4',
+            desc: 'Emphasis on advanced camera and lighting techniques.  Use of architectural exteriors, interiors, landscapes and studio set-ups to assist mastery of large format cameras.  Other topics include perspective and sharpness correction, lighting (available and artificial), digital imaging and studio equipment.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: F\nPrerequisite: ART 224.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART329',
+            catalog: '2017-2019',
+            displayName: 'Editorial Photography',
+            units: '4',
+            desc: 'Creating, lighting and executing editorial assignments.  Producing photography for corporate needs, i.e.  annual reports, online presentations, brochures and in-house publications.  Emphasis on selecting subject matter and handling lights.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: ART 325.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART383',
+            catalog: '2017-2019',
+            displayName: 'Digital Video I',
+            units: '4',
+            desc: 'Introduction to the use of the DSLR camera as a tool for shooting video and basic digital editing including audio editing.  Topics will include scripting, storyboarding, composition, motion, editing, lighting and sound.  Emphasis on effective communication and expression.  2 lectures, 2 laboratories.\n',
+            addl: 'Term Typically Offered: F, SP\nPrerequisite: ART 122 or ART 224.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART427',
+            catalog: '2017-2019',
+            displayName: 'Advertising Photography',
+            units: '4',
+            desc: 'Applied principles of design and color to produce a photograph that sells an idea, product, or service.  Joint projects with ART 432, Advertising Design.  Emphasis on thinking, planning, interpreting, and presenting an idea photographically.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: ART 325 and senior standing.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART463',
+            catalog: '2017-2019',
+            displayName: 'Senior Portfolio Project',
+            units: '4',
+            desc: 'Planning, preparation, and physical production of a portfolio of work for entrance into the professional job market or graduate school.  3 lectures, 1 laboratory.\n',
+            addl: 'Term Typically Offered: SP\nPrerequisite: Senior standing; and ART 260.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ART483',
+            catalog: '2017-2019',
+            displayName: 'Digital Video II',
+            units: '4',
+            desc: 'Advanced practices in digital video.  Creation of genre-specific narratives using methods in storyboarding, shooting, editing, and sound design.  Advanced methods of storytelling, including documentary video, web-based narratives, and fine art video practices.  Creation of quality expressive videos.  2 lectures, 2 laboratories.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: ART 383.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'ENGL371',
+            catalog: '2017-2019',
+            displayName: 'Film Styles and Genres',
+            units: '4',
+            desc: "Major films within particular cinematic genres or styles, with emphasis on critical interpretation, aesthetic appreciation, and the films' historical and cultural contexts.  The Schedule of Classes will list topic selected.  Total credit limited to 12 units.  3 lectures, 1 laboratory.  Fulfills GE C4 except for English majors.  Fulfills GWR for students with junior standing (90 units).\n",
+            addl: 'GE Area C4; GWR\nTerm Typically Offered: W\nPrerequisite: Junior standing or English major; completion of GE Area A with a grade of C- or better; and completion of GE Area C1.\n',
+            gwrCourse: true,
+            uscpCourse: false,
+            dynamicTerms: null
+          },
+          {
+            id: 'GRC331',
+            catalog: '2017-2019',
+            displayName: 'Color Management and Quality Analysis',
+            units: '4',
+            desc: 'The physics, psychology, measurement, analysis and management of color for print and electronic documents, including web sites.  Practical application of color correction, color proofing, and production workflows that ensure the best possible color reproduction.  3 lectures, 1 activity.\n',
+            addl: 'Term Typically Offered: W\nPrerequisite: Completion of GE Area B3 and either ART 182 or GRC 202.\n',
+            gwrCourse: false,
+            uscpCourse: false,
+            dynamicTerms: null
           }
-        },
-        {
-          id: 'AGB212',
-          catalog: '2015-2017',
-          displayName: 'Agricultural Economics',
-          units: '4',
-          desc: 'Theoretical development of factors affecting demand and supply for food and fiber and for agricultural inputs. Methods of selecting optimal levels of agricultural production and consumption variables. Evaluation of market structure and price formulation for agricultural products and resources. 4 lectures.\n',
-          addl: 'Term Typically Offered: F, W, SP\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'AGB214',
-          catalog: '2015-2017',
-          displayName: 'Agribusiness Financial Accounting',
-          units: '4',
-          desc: 'Principles of financial accounting in agribusiness. Preparation for understanding and interpreting financial statements. Exploration of financial reporting standards to provide an understanding of how financial events are reflected in financial statements. The importance of social responsibility in accounting. The accounting cycle, from transactions posting to financial statements through spreadsheet applications. 3 lectures, 1 activity.\n',
-          addl: 'Term Typically Offered: F, W, SP\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'AGB260',
-          catalog: '2015-2017',
-          displayName: 'Agribusiness Data Literacy',
-          units: '4',
-          desc: 'Using data and analysis in making decisions related to agribusiness.  Developing basic and intermediate spreadsheet skills necessary to organize, analyze, and summarize information.  Development of data management and analysis as tools to assist in agribusiness problem-solving.  4 lectures.\n',
-          addl: 'Term Typically Offered: F,W,SP,SU\nPrerequisite: AGB 101 or junior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'AGB301',
-          catalog: '2015-2017',
-          displayName: 'Food and Fiber Marketing',
-          units: '4',
-          desc: 'Food and fiber marketing, examining commodity, industrial, and consumer product marketing from a managerial viewpoint.  A global perspective in understanding consumer needs and developing the knowledge of economic, political, social and environmental factors that affect food and fiber marketing systems.  4 lectures.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 221.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'AGB308',
-          catalog: '2015-2017',
-          displayName: 'Introduction to Agribusiness Finance',
-          units: '4',
-          desc: 'Concepts and analytical methods related to agricultural finance.  Focus on applied spreadsheet analysis of financial statements, time value of money, risk and return, portfolio theory, and capital budgeting within the context of financial institutions specific to agriculture.  Not open to students with credit in AGB 310.  4 lectures.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 214 and AGB 260.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'AGB312',
-          catalog: '2015-2017',
-          displayName: 'Agricultural Policy',
-          units: '4',
-          desc: 'Agricultural policy objectives and formulation, resource allocation and production adjustments.  Survey of State and Federal agricultural policies as they influence the planning and practices of agribusiness.  4 lectures.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 and ECON 222.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'AGB313',
-          catalog: '2015-2017',
-          displayName: 'Agriculture Economic Analysis',
-          units: '4',
-          desc: 'Advanced agricultural microeconomics with emphasis on mathematical problem solving; production and cost functions, single and multiple input allocation, agricultural output combinations, agricultural market structures, and economies of size.  4 lectures.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 and MATH 221.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'AGB323',
-          catalog: '2015-2017',
-          displayName: 'Agribusiness Managerial Accounting',
-          units: '4',
-          desc: 'Agribusiness management with an emphasis on using accounting procedures that will provide useful information in making management decisions, setting objectives, and controlling operations.  3 lectures, 1 activity.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 214.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'AGB327',
-          catalog: '2015-2017',
-          displayName: 'Agribusiness Data Analysis',
-          units: '4',
-          desc: 'Methods in agricultural business data analysis, including multiple regression analysis, analysis of variance, and time series analysis.  Applications include agricultural price forecasting and estimation of the determinants of food and fiber demand.  3 lectures, 1 activity.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: STAT 251 and AGB 260.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'AGB328',
-          catalog: '2015-2017',
-          displayName: 'Decision Tools for Agribusiness',
-          units: '4',
-          desc: 'Development of agribusiness modeling techniques that are applied to solving a diverse and unique set of resource allocation issues encountered throughout the agricultural and food retail sectors.  Techniques include linear programming, decision analysis, and computer simulations.  3 lectures, 1 activity.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: STAT 251 and AGB 260.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'AGB369',
-          catalog: '2015-2017',
-          displayName: 'Agricultural Personnel Management',
-          units: '4',
-          desc: 'Standard topics of California agricultural personnel management:  recruitment; appraisal and performance evaluation; compensation; training and development; discipline; safety and health; labor relations; and immigration policy.  Systemic approach to aspects of managing human capital, and how to implement human resource policies.  Not open to students with credit in AGB 401.  4 lectures.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: AGB 212 or ECON 201 or ECON 221; and junior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'BUS207',
-          catalog: '2015-2017',
-          displayName: 'Legal Responsibilities of Business',
-          units: '4',
-          desc: 'Examination of the American legal system and important legal principles for business operations, such as those involved with contracts, torts, agency, business organizations, and employment. Emphasis on how legal principles help define socially responsible conduct. Case studies. 4 lectures.\n',
-          addl: 'Term Typically Offered: F, W, SP\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: true,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'CHEM110',
-          catalog: '2015-2017',
-          displayName: 'World of Chemistry',
-          units: '4',
-          desc: 'The fundamentals of chemical cause and effect-structure/function relationships.  The basic principles of chemistry and their applications to solving human problems in organic materials science, biochemistry, toxicology, environmental science, agriculture, nutrition, and medicine.  Not open to students majoring in Chemistry or Biochemistry.  Not open to students with credit in CHEM 111, CHEM 124, or CHEM 127.  3 lectures, 1 laboratory.  Fulfills GE B3 & B4.\n',
-          addl: 'GE Area B3; GE Area B4\nTerm Typically Offered: F, W, SP\nPrerequisite: Passing score on ELM examination, or an ELM exemption, or MATH 104.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: true,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'COMS101',
-          catalog: '2015-2017',
-          displayName: 'Public Speaking',
-          units: '4',
-          desc: 'Introduction to the principles of public speaking. Practical experience in the development, presentation, and critical analysis of speeches to inform, to persuade, and to actuate. Not open to students with credit in COMS 102. 4 lectures. Crosslisted as COMS/HNRS 101. Fulfills GE A2; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A2.\n',
-          addl: 'GE Area A2\nTerm Typically Offered: F,W,SP,SU\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: true,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'COMS126',
-          catalog: '2015-2017',
-          displayName: 'Argument and Advocacy',
-          units: '4',
-          desc: 'The nature of critical thinking as applied in written and oral argument.  Analysis of inductive and deductive reasoning.  Analysis of reasoning, argument, forms of support and fallacies of argument and language.  Instruction in and practical experience in writing sound persuasive arguments and engaging in oral argumentation assignments.  4 lectures.  Fulfills GE A3; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A3.\n',
-          addl: 'GE Area A3\nTerm Typically Offered: W, SP\nPrerequisite: Completion of GE Area A1 with a C- or better, or consent of instructor. Recommended: Completion of GE Area A2.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: false,
-            termSpring: false
-          }
-        },
-        {
-          id: 'ECON222',
-          catalog: '2015-2017',
-          displayName: 'Macroeconomics',
-          units: '4',
-          desc: 'Introduction to economic problems. Macroeconomic analysis and principles. Aggregate output, employment, prices, and economic policies for changing these variables. International trade and finance. Issues of economic growth and development. Comparative economic systems and economies in transition. 4 lectures. Fulfills GE D2.\n',
-          addl: 'GE Area D2\nTerm Typically Offered: F,W,SP,SU\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ENGL134',
-          catalog: '2015-2017',
-          displayName: 'Writing and Rhetoric',
-          units: '4',
-          desc: 'Rhetorical principles and tactics applied to written work.  Writing as a recursive process that leads to greater organizational coherency, stylistic complexity, and rhetorical awareness.  4 lectures.  Fulfills GE A1; for students admitted Fall 2016 or later a grade of C- or better is required to fulfill GE Area A1.\n',
-          addl: 'GE Area A1\nTerm Typically Offered: F, W, SP\nPrerequisite: Satisfactory score on the English Placement Test.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'MATH221',
-          catalog: '2015-2017',
-          displayName: 'Calculus for Business and Economics',
-          units: '4',
-          desc: 'Polynomial calculus for optimization and marginal analysis, and elementary integration.  Not open to students with credit in MATH 142.  4 lectures.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
-          addl: 'GE Area B1\nTerm Typically Offered: W, SP\nPrerequisite: Completion of ELM requirement and passing score on appropriate Mathematics Placement Examination, or MATH 118.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: false,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'STAT251',
-          catalog: '2015-2017',
-          displayName: 'Statistical Inference for Management I',
-          units: '4',
-          desc: 'Descriptive statistics.  Probability and counting rules.  Random variables and probability distributions.  Sampling distributions and point estimation.  Confidence intervals and tests of hypotheses for a single mean and proportion.  4 lectures.  Fulfills GE B1; for students admitted Fall 2016 or later, a grade of C- or better in one GE B1 course is required to fulfill GE Area B.\n',
-          addl: 'GE Area B1\nTerm Typically Offered: F, W, SP\nPrerequisite: Completion of the ELM requirement and a passing score on appropriate Mathematics Placement Examination for MATH 221 eligibility, or MATH 118 or equivalent.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        }
-      ]
-    },
-    {
-      catalog: '2017-2019',
-      courses: [
-        {
-          id: 'ART101',
-          catalog: '2017-2019',
-          displayName: 'The Fundamentals of Drawing',
-          units: '4',
-          desc: 'Introduction to the artistic practice and cultural value of drawing from the Renaissance to the 21st Century. Emphasis and expansion of the practical skills of observation, rendering, and understanding the signs of meaning produced in visual art. Development of formal techniques, media experimentation, and content creation through personal expression. Exercises to encourage growth in technical skill, conceptual innovation, critical thinking, and visual communication. 3 lectures, 1 laboratory. Fulfills GE C3.\n',
-          addl: 'GE Area C3\nTerm Typically Offered: F, W, SP\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ART102',
-          catalog: '2017-2019',
-          displayName: 'Art and Design Foundation Studies I',
-          units: '4',
-          desc: 'Introduces elements and principles of design, establishing a foundation for all artistic practice. Emphasizing critical thinking and creative problem solving, the interrelationship between form and content are examined. Traditional, digital and lens-based media are explored through individual and collaborative experiences. 3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: F\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: false,
-            termSpring: false
-          }
-        },
-        {
-          id: 'ART103',
-          catalog: '2017-2019',
-          displayName: 'Art and Design Foundation Studies II',
-          units: '4',
-          desc: 'Visual and aesthetic interactions of color, examined through historical and contemporary models.  Formal techniques, media experimentation and content creation, explored through individual and collaborative experiences.  3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: ART 102.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: null
-        },
-        {
-          id: 'ART104',
-          catalog: '2017-2019',
-          displayName: 'Art and Design Foundation Studies III',
-          units: '4',
-          desc: 'Principles and essential skills for three-dimensional practice in art and design.  Understanding, envisioning, and communicating effectively about space, objects, scale, and the relationship of the body to the built environment.  3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: ART 103.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: false,
-            termWinter: false,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ART122',
-          catalog: '2017-2019',
-          displayName: 'Basic Digital Photography',
-          units: '4',
-          desc: 'Fundamental techniques in photography. Mechanics of digital cameras, optics, composition, perception of light and subject content. Understanding photographic principles and the language of camera vision. Introduction to the impact of photography on culture. Digital camera required. 3 lectures, 1 laboratory. Fulfills GE C3.\n',
-          addl: 'GE Area C3\nTerm Typically Offered: F, W, SP\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ART182',
-          catalog: '2017-2019',
-          displayName: 'Foundation in Digital Art I',
-          units: '4',
-          desc: 'Introduction to image creation and manipulation, design, illustration, and layout/composition using digital tools, with an emphasis on visual problem solving and creative expression. 3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: F\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: false,
-            termSpring: false
-          }
-        },
-        {
-          id: 'ART203',
-          catalog: '2017-2019',
-          displayName: 'Art Theory and Practice',
-          units: '4',
-          desc: "Contemporary issues in art and design, linking 'ideas' to development of concepts.  Emphasis on individual creative process, and problem solving.  Focus on contemporary critical thinking regarding aesthetics, techniques, and vocabulary.  3 lectures, 1 laboratory.\n",
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: ART 101; and ART 102 or ART 106.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ART209',
-          catalog: '2017-2019',
-          displayName: 'Beginning Painting',
-          units: '4',
-          desc: 'Introduction to technical and formal problems in painting.  Exploration of pictorial space, light, and color from observation.  Physical characteristics of paint, various tools, studio methods, and styles of painting.  3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: F, W, SP\nPrerequisite: ART 101.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: false
-          }
-        },
-        {
-          id: 'ART212',
-          catalog: '2017-2019',
-          displayName: 'Art History - Renaissance through Baroque Eras',
-          units: '4',
-          desc: 'The significant visual expressions of Northern and Southern European art of the Renaissance and Baroque period. Relevant parallel examples of the art of antiquity and non-European cultures. 4 lectures.\n',
-          addl: 'Term Typically Offered: W, SP\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: false
-          }
-        },
-        {
-          id: 'ART213',
-          catalog: '2017-2019',
-          displayName: 'Art History- Modern Art, 1900-1945',
-          units: '4',
-          desc: 'Examines the development of significant styles and movements in modern art, including Fauvism, German Expressionism, Cubism, Futurism, Neo-Plasticism, Russian and Soviet avant-gardes, Dada, Surrealism, and/or American modernism. Also introduces selected modern developments in graphic design and photography. 4 lectures. Replaces ART 312.\n',
-          addl: 'Term Typically Offered: F\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: false,
-            termWinter: false,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ART222',
-          catalog: '2017-2019',
-          displayName: 'Black and White Photography',
-          units: '4',
-          desc: "Control and understanding of tonal range under available light. Composition, camera based visual communication skills and concept development. Emphasis on 'photographic seeing' and professional quality printing. 2 lectures, 2 laboratories.\n",
-          addl: 'Term Typically Offered: SP\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: false,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ART224',
-          catalog: '2017-2019',
-          displayName: 'Introduction to Artificial Lighting for Photography',
-          units: '4',
-          desc: 'Introduction to studio lighting and contemporary professional studio photography. Production of professional quality prints using digital camera and printing methods. 3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: F, W, SP\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ART260',
-          catalog: '2017-2019',
-          displayName: 'Critique, Discourse and Practice',
-          units: '4',
-          desc: 'Developing an individual body of artwork.  Rigorous critiques, lectures, and seminar-style discussions aimed at forming a process for discussing artwork.  Art writing, research, and individual conceptual and formal development.  4 lectures.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: ART 101 and ART 104.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: false,
-            termWinter: false,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ART314',
-          catalog: '2017-2019',
-          displayName: 'History of Photography',
-          units: '4',
-          desc: 'In-depth survey of the artistic and cultural achievements in photography from its invention to the present day.  Significant photographers, the evolution of aesthetic criteria in the context of other visual arts as well as social/cultural impact.  4 lectures.  Fulfills GE C4 except for Art and Design majors.\n',
-          addl: 'GE Area C4\nTerm Typically Offered: W\nPrerequisite: Junior standing; completion of GE Area A with a grade of C- or better; and completion of GE Area C3.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: true,
-            termSpring: false
-          }
-        },
-        {
-          id: 'ART315',
-          catalog: '2017-2019',
-          displayName: 'Art History - Art Since 1945',
-          units: '4',
-          desc: 'History of visual art from 1945 to the present.  Focus on significant movements such as Abstract Expressionism, Pop art, minimalism, conceptual art, earthworks, feminism, and postmodernism.  Also focus on new mediums such as performance, video, and installation.  4 lectures.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: ART 112 or ART 211 or ART 212 or ART 213; and Junior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: false,
-            termWinter: true,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ART324',
-          catalog: '2017-2019',
-          displayName: 'Photographic Expression',
-          units: '4',
-          desc: 'Emphasis on personal expression and developing style, introduction to symbology, visual source development and the work of contemporary creative photographers.  Total credit limited to 8 units.  3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: ART 122 or ART 224. Recommended: ART 222.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: false,
-            termSpring: false
-          }
-        },
-        {
-          id: 'ART325',
-          catalog: '2017-2019',
-          displayName: 'Advanced Camera and Lighting Techniques',
-          units: '4',
-          desc: 'Emphasis on advanced camera and lighting techniques.  Use of architectural exteriors, interiors, landscapes and studio set-ups to assist mastery of large format cameras.  Other topics include perspective and sharpness correction, lighting (available and artificial), digital imaging and studio equipment.  3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: F\nPrerequisite: ART 224.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: false,
-            termSpring: false
-          }
-        },
-        {
-          id: 'ART329',
-          catalog: '2017-2019',
-          displayName: 'Editorial Photography',
-          units: '4',
-          desc: 'Creating, lighting and executing editorial assignments.  Producing photography for corporate needs, i.e.  annual reports, online presentations, brochures and in-house publications.  Emphasis on selecting subject matter and handling lights.  3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: ART 325.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: false,
-            termWinter: true,
-            termSpring: false
-          }
-        },
-        {
-          id: 'ART383',
-          catalog: '2017-2019',
-          displayName: 'Digital Video I',
-          units: '4',
-          desc: 'Introduction to the use of the DSLR camera as a tool for shooting video and basic digital editing including audio editing.  Topics will include scripting, storyboarding, composition, motion, editing, lighting and sound.  Emphasis on effective communication and expression.  2 lectures, 2 laboratories.\n',
-          addl: 'Term Typically Offered: F, SP\nPrerequisite: ART 122 or ART 224.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: true,
-            termWinter: false,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ART427',
-          catalog: '2017-2019',
-          displayName: 'Advertising Photography',
-          units: '4',
-          desc: 'Applied principles of design and color to produce a photograph that sells an idea, product, or service.  Joint projects with ART 432, Advertising Design.  Emphasis on thinking, planning, interpreting, and presenting an idea photographically.  3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: ART 325 and senior standing.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: false,
-            termWinter: true,
-            termSpring: false
-          }
-        },
-        {
-          id: 'ART463',
-          catalog: '2017-2019',
-          displayName: 'Senior Portfolio Project',
-          units: '4',
-          desc: 'Planning, preparation, and physical production of a portfolio of work for entrance into the professional job market or graduate school.  3 lectures, 1 laboratory.\n',
-          addl: 'Term Typically Offered: SP\nPrerequisite: Senior standing; and ART 260.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: false,
-            termWinter: false,
-            termSpring: true
-          }
-        },
-        {
-          id: 'ART483',
-          catalog: '2017-2019',
-          displayName: 'Digital Video II',
-          units: '4',
-          desc: 'Advanced practices in digital video.  Creation of genre-specific narratives using methods in storyboarding, shooting, editing, and sound design.  Advanced methods of storytelling, including documentary video, web-based narratives, and fine art video practices.  Creation of quality expressive videos.  2 lectures, 2 laboratories.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: ART 383.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: false,
-            termWinter: true,
-            termSpring: false
-          }
-        },
-        {
-          id: 'ENGL371',
-          catalog: '2017-2019',
-          displayName: 'Film Styles and Genres',
-          units: '4',
-          desc: "Major films within particular cinematic genres or styles, with emphasis on critical interpretation, aesthetic appreciation, and the films' historical and cultural contexts.  The Schedule of Classes will list topic selected.  Total credit limited to 12 units.  3 lectures, 1 laboratory.  Fulfills GE C4 except for English majors.  Fulfills GWR for students with junior standing (90 units).\n",
-          addl: 'GE Area C4; GWR\nTerm Typically Offered: W\nPrerequisite: Junior standing or English major; completion of GE Area A with a grade of C- or better; and completion of GE Area C1.\n',
-          gwrCourse: true,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: false,
-            termWinter: false,
-            termSpring: false
-          }
-        },
-        {
-          id: 'GRC331',
-          catalog: '2017-2019',
-          displayName: 'Color Management and Quality Analysis',
-          units: '4',
-          desc: 'The physics, psychology, measurement, analysis and management of color for print and electronic documents, including web sites.  Practical application of color correction, color proofing, and production workflows that ensure the best possible color reproduction.  3 lectures, 1 activity.\n',
-          addl: 'Term Typically Offered: W\nPrerequisite: Completion of GE Area B3 and either ART 182 or GRC 202.\n',
-          gwrCourse: false,
-          uscpCourse: false,
-          dynamicTerms: {
-            termSummer: false,
-            termFall: false,
-            termWinter: true,
-            termSpring: false
-          }
-        }
-      ]
-    }
-  ]
-    // sort to ensure order of items doesn't matter in cache
-    .map((cache) => {
-      return {
-        catalog: cache.catalog,
-        courses: cache.courses.sort((a, b) => a.id.localeCompare(b.id))
-      };
-    })
-    .sort((a, b) => a.catalog.localeCompare(b.catalog))
+        ]
+      )
+    ]
+  ])
 };

--- a/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
+++ b/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
@@ -471,7 +471,7 @@ test.describe('generate flowchart api output tests', () => {
     const { courseCache: actCourseCache, ...actRest } = actualResponseBody;
 
     // verify course caches are the same
-    verifyCourseCacheStrictEquality(expCourseCache, actCourseCache);
+    await verifyCourseCacheStrictEquality(expCourseCache, actCourseCache, 'playwright');
 
     // verify everything else is the same
     expect(actRest).toStrictEqual(expRest);
@@ -581,7 +581,7 @@ test.describe('generate flowchart api output tests', () => {
     const { courseCache: actCourseCache, ...actRest } = actualResponseBody;
 
     // verify course caches are the same
-    verifyCourseCacheStrictEquality(expCourseCache, actCourseCache);
+    await verifyCourseCacheStrictEquality(expCourseCache, actCourseCache, 'playwright');
 
     // verify everything else is the same
     expect(actRest).toStrictEqual(expRest);
@@ -643,7 +643,7 @@ test.describe('generate flowchart api output tests', () => {
     const { courseCache: actCourseCache, ...actRest } = actualResponseBody;
 
     // verify course caches are the same
-    verifyCourseCacheStrictEquality(expCourseCache, actCourseCache);
+    await verifyCourseCacheStrictEquality(expCourseCache, actCourseCache, 'playwright');
 
     // verify everything else is the same
     expect(actRest).toStrictEqual(expRest);
@@ -707,7 +707,7 @@ test.describe('generate flowchart api output tests', () => {
     const { courseCache: actCourseCache, ...actRest } = actualResponseBody;
 
     // verify course caches are the same
-    verifyCourseCacheStrictEquality(expCourseCache, actCourseCache);
+    await verifyCourseCacheStrictEquality(expCourseCache, actCourseCache, 'playwright');
 
     // verify everything else is the same
     expect(actRest).toStrictEqual(expRest);

--- a/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
+++ b/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
@@ -1,23 +1,25 @@
 import crypto from 'crypto';
+import { ObjectSet } from '$lib/common/util/ObjectSet';
 import { expect, test } from '@playwright/test';
 import { FLOW_NAME_MAX_LENGTH } from '$lib/common/config/flowDataConfig';
 import { createUser, deleteUser } from '$lib/server/db/user';
+import { deleteObjectProperties } from 'tests/util/testUtil';
 import { flowchartValidationSchema } from '$lib/common/schema/flowchartSchema';
+import { verifyCourseCacheStrictEquality } from 'tests/util/courseCacheUtil';
 import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
-import { cloneAndDeleteNestedProperty, deleteObjectProperties } from 'tests/util/testUtil';
 import {
   responsePayload1,
   responsePayload2,
   responsePayload3
 } from 'tests/api/generateFlowchartApiTests/expectedResponsePayloads';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
-import type { CourseCache } from '$lib/types/apiDataTypes';
+import type { APICourseFull } from '$lib/types/apiDataTypes';
 
 // see API for expected return type
 interface GenerateFlowchartExpectedReturnType {
   message: string;
   generatedFlowchart: Flowchart;
-  courseCache: CourseCache[] | undefined;
+  courseCache: [string, APICourseFull[]][] | undefined;
 }
 
 test.describe('generate flowchart api input tests', () => {
@@ -425,7 +427,7 @@ test.describe('generate flowchart api output tests', () => {
     );
     expect(res.status()).toBe(200);
 
-    // make sure date is serialized back to Date object for flowchart validation
+    // make sure date is deserialized back to Date object for flowchart validation
     const resData = (await res.json()) as GenerateFlowchartExpectedReturnType;
     resData.generatedFlowchart.lastUpdatedUTC = new Date(resData.generatedFlowchart.lastUpdatedUTC);
 
@@ -442,29 +444,37 @@ test.describe('generate flowchart api output tests', () => {
     // do it this way so when it fails we know what validation step failed
     expect(() => flowchartValidationSchema.parse(resData.generatedFlowchart)).not.toThrowError();
 
-    // remove these fields before comparison but after validation since they change on every request
-    const resDataRelevantProperties = {
+    const actualResponseBody = {
       message: resData.message,
+      // remove these fields before comparison but after validation since they change on every request
       generatedFlowchart: deleteObjectProperties(resData.generatedFlowchart, [
         'id',
         'hash',
         'lastUpdatedUTC'
       ]),
-      // sort to ensure order of items doesn't matter in cache
+      // deserialize course cache
       courseCache: resData.courseCache
-        ?.map((cache) => {
-          return {
-            catalog: cache.catalog,
-            courses: cache.courses.sort((a, b) => a.id.localeCompare(b.id))
-          };
-        })
-        .sort((a, b) => a.catalog.localeCompare(b.catalog))
+        ? new Map(
+            resData.courseCache.map(([catalog, courses]) => {
+              return [catalog, new ObjectSet((crs) => crs.id, courses)];
+            })
+          )
+        : undefined
     };
 
-    // remove dynamicTerms as this can change over time
-    expect(cloneAndDeleteNestedProperty(resDataRelevantProperties, 'dynamicTerms')).toStrictEqual(
-      cloneAndDeleteNestedProperty(expectedResponseBody, 'dynamicTerms')
-    );
+    // for type safety
+    if (!actualResponseBody.courseCache) {
+      throw new Error('actualResponseBody courseCache is undefined');
+    }
+
+    const { courseCache: expCourseCache, ...expRest } = expectedResponseBody;
+    const { courseCache: actCourseCache, ...actRest } = actualResponseBody;
+
+    // verify course caches are the same
+    verifyCourseCacheStrictEquality(expCourseCache, actCourseCache);
+
+    // verify everything else is the same
+    expect(actRest).toStrictEqual(expRest);
   });
 
   test('generate valid flowchart with 1 program without coursecache', async ({ request }) => {
@@ -480,7 +490,7 @@ test.describe('generate flowchart api output tests', () => {
     );
     expect(res.status()).toBe(200);
 
-    // make sure date is serialized back to Date object
+    // make sure date is deserialized back to Date object
     const resData = (await res.json()) as GenerateFlowchartExpectedReturnType;
     resData.generatedFlowchart.lastUpdatedUTC = new Date(resData.generatedFlowchart.lastUpdatedUTC);
 
@@ -496,9 +506,9 @@ test.describe('generate flowchart api output tests', () => {
     // do it this way so when it fails we know what validation step failed
     expect(() => flowchartValidationSchema.parse(resData.generatedFlowchart)).not.toThrowError();
 
-    // remove these fields before comparison but after validation since they change on every request
     const resDataRelevantProperties = {
       message: resData.message,
+      // remove these fields before comparison but after validation since they change on every request
       generatedFlowchart: deleteObjectProperties(resData.generatedFlowchart, [
         'id',
         'hash',
@@ -506,10 +516,7 @@ test.describe('generate flowchart api output tests', () => {
       ])
     };
 
-    // remove dynamicTerms as this can change over time
-    expect(cloneAndDeleteNestedProperty(resDataRelevantProperties, 'dynamicTerms')).toStrictEqual(
-      cloneAndDeleteNestedProperty(expectedResponseBody, 'dynamicTerms')
-    );
+    expect(resDataRelevantProperties).toStrictEqual(expectedResponseBody);
   });
 
   test('generate valid flowchart with 1 program without ge courses', async ({ request }) => {
@@ -525,9 +532,14 @@ test.describe('generate flowchart api output tests', () => {
     );
     expect(res.status()).toBe(200);
 
-    // make sure date is serialized back to Date object
+    // make sure date is deserialized back to Date object
     const resData = (await res.json()) as GenerateFlowchartExpectedReturnType;
     resData.generatedFlowchart.lastUpdatedUTC = new Date(resData.generatedFlowchart.lastUpdatedUTC);
+
+    // remove GE courses from expected payload
+    const expCourseCacheNoGE = new Map(responsePayload1.courseCache.entries());
+    expCourseCacheNoGE.get('2015-2017')?.deleteByKey('ENGL134');
+    expCourseCacheNoGE.get('2015-2017')?.deleteByKey('COMS101');
 
     const expectedResponseBody = {
       message: 'Flowchart successfully generated.',
@@ -535,33 +547,44 @@ test.describe('generate flowchart api output tests', () => {
         ...responsePayload1.generatedFlowchartNoGE,
         ownerId
       },
-      courseCache: responsePayload1.courseCache
+      courseCache: expCourseCacheNoGE
     };
-    // to satisfy type safety
-    const cache = expectedResponseBody.courseCache.find((cache) => cache.catalog === '2015-2017');
-    if (cache) {
-      cache.courses = cache.courses.filter((crs) => !['ENGL134', 'COMS101'].includes(crs.id));
-    }
 
     // verify that we got a valid flowchart back
     // do it this way so when it fails we know what validation step failed
     expect(() => flowchartValidationSchema.parse(resData.generatedFlowchart)).not.toThrowError();
 
-    // remove these fields before comparison but after validation since they change on every request
-    const resDataRelevantProperties = {
+    const actualResponseBody = {
       message: resData.message,
+      // remove these fields before comparison but after validation since they change on every request
       generatedFlowchart: deleteObjectProperties(resData.generatedFlowchart, [
         'id',
         'hash',
         'lastUpdatedUTC'
       ]),
+      // deserialize course cache
       courseCache: resData.courseCache
+        ? new Map(
+            resData.courseCache.map(([catalog, courses]) => {
+              return [catalog, new ObjectSet((crs) => crs.id, courses)];
+            })
+          )
+        : undefined
     };
 
-    // remove dynamicTerms as this can change over time
-    expect(cloneAndDeleteNestedProperty(resDataRelevantProperties, 'dynamicTerms')).toStrictEqual(
-      cloneAndDeleteNestedProperty(expectedResponseBody, 'dynamicTerms')
-    );
+    // for type safety
+    if (!actualResponseBody.courseCache) {
+      throw new Error('actualResponseBody courseCache is undefined');
+    }
+
+    const { courseCache: expCourseCache, ...expRest } = expectedResponseBody;
+    const { courseCache: actCourseCache, ...actRest } = actualResponseBody;
+
+    // verify course caches are the same
+    verifyCourseCacheStrictEquality(expCourseCache, actCourseCache);
+
+    // verify everything else is the same
+    expect(actRest).toStrictEqual(expRest);
   });
 
   test('generate valid flowchart with multiple programs', async ({ request }) => {
@@ -576,7 +599,7 @@ test.describe('generate flowchart api output tests', () => {
     );
     expect(res.status()).toBe(200);
 
-    // make sure date is serialized back to Date object
+    // make sure date is deserialized back to Date object
     const resData = (await res.json()) as GenerateFlowchartExpectedReturnType;
     resData.generatedFlowchart.lastUpdatedUTC = new Date(resData.generatedFlowchart.lastUpdatedUTC);
 
@@ -593,29 +616,37 @@ test.describe('generate flowchart api output tests', () => {
     // do it this way so when it fails we know what validation step failed
     expect(() => flowchartValidationSchema.parse(resData.generatedFlowchart)).not.toThrowError();
 
-    // remove these fields before comparison but after validation since they change on every request
-    const resDataRelevantProperties = {
+    const actualResponseBody = {
       message: resData.message,
+      // remove these fields before comparison but after validation since they change on every request
       generatedFlowchart: deleteObjectProperties(resData.generatedFlowchart, [
         'id',
         'hash',
         'lastUpdatedUTC'
       ]),
-      // sort to ensure order of items doesn't matter in cache
+      // deserialize course cache
       courseCache: resData.courseCache
-        ?.map((cache) => {
-          return {
-            catalog: cache.catalog,
-            courses: cache.courses.sort((a, b) => a.id.localeCompare(b.id))
-          };
-        })
-        .sort((a, b) => a.catalog.localeCompare(b.catalog))
+        ? new Map(
+            resData.courseCache.map(([catalog, courses]) => {
+              return [catalog, new ObjectSet((crs) => crs.id, courses)];
+            })
+          )
+        : undefined
     };
 
-    // remove dynamicTerms as this can change over time
-    expect(cloneAndDeleteNestedProperty(resDataRelevantProperties, 'dynamicTerms')).toStrictEqual(
-      cloneAndDeleteNestedProperty(expectedResponseBody, 'dynamicTerms')
-    );
+    // for type safety
+    if (!actualResponseBody.courseCache) {
+      throw new Error('actualResponseBody courseCache is undefined');
+    }
+
+    const { courseCache: expCourseCache, ...expRest } = expectedResponseBody;
+    const { courseCache: actCourseCache, ...actRest } = actualResponseBody;
+
+    // verify course caches are the same
+    verifyCourseCacheStrictEquality(expCourseCache, actCourseCache);
+
+    // verify everything else is the same
+    expect(actRest).toStrictEqual(expRest);
   });
 
   test('generate valid flowchart with multiple programs #2 (input programs exposed to indeterministic ordering)', async ({
@@ -632,7 +663,7 @@ test.describe('generate flowchart api output tests', () => {
     );
     expect(res.status()).toBe(200);
 
-    // make sure date is serialized back to Date object
+    // make sure date is deserialized back to Date object
     const resData = (await res.json()) as GenerateFlowchartExpectedReturnType;
     resData.generatedFlowchart.lastUpdatedUTC = new Date(resData.generatedFlowchart.lastUpdatedUTC);
 
@@ -649,28 +680,36 @@ test.describe('generate flowchart api output tests', () => {
     // do it this way so when it fails we know what validation step failed
     expect(() => flowchartValidationSchema.parse(resData.generatedFlowchart)).not.toThrowError();
 
-    // remove these fields before comparison but after validation since they change on every request
-    const resDataRelevantProperties = {
+    const actualResponseBody = {
       message: resData.message,
+      // remove these fields before comparison but after validation since they change on every request
       generatedFlowchart: deleteObjectProperties(resData.generatedFlowchart, [
         'id',
         'hash',
         'lastUpdatedUTC'
       ]),
-      // sort to ensure order of items doesn't matter in cache
+      // deserialize course cache
       courseCache: resData.courseCache
-        ?.map((cache) => {
-          return {
-            catalog: cache.catalog,
-            courses: cache.courses.sort((a, b) => a.id.localeCompare(b.id))
-          };
-        })
-        .sort((a, b) => a.catalog.localeCompare(b.catalog))
+        ? new Map(
+            resData.courseCache.map(([catalog, courses]) => {
+              return [catalog, new ObjectSet((crs) => crs.id, courses)];
+            })
+          )
+        : undefined
     };
 
-    // remove dynamicTerms as this can change over time
-    expect(cloneAndDeleteNestedProperty(resDataRelevantProperties, 'dynamicTerms')).toStrictEqual(
-      cloneAndDeleteNestedProperty(expectedResponseBody, 'dynamicTerms')
-    );
+    // for type safety
+    if (!actualResponseBody.courseCache) {
+      throw new Error('actualResponseBody courseCache is undefined');
+    }
+
+    const { courseCache: expCourseCache, ...expRest } = expectedResponseBody;
+    const { courseCache: actCourseCache, ...actRest } = actualResponseBody;
+
+    // verify course caches are the same
+    verifyCourseCacheStrictEquality(expCourseCache, actCourseCache);
+
+    // verify everything else is the same
+    expect(actRest).toStrictEqual(expRest);
   });
 });

--- a/tests/api/getUserFlowchartsTests.test.ts
+++ b/tests/api/getUserFlowchartsTests.test.ts
@@ -339,13 +339,14 @@ test.describe('getUserFlowcharts API tests', () => {
     }
 
     // verify course caches are the same
-    verifyCourseCacheStrictEquality(
+    await verifyCourseCacheStrictEquality(
       expCourseCache,
       new Map(
         actCourseCache.map(([catalog, courses]) => {
           return [catalog, new ObjectSet((crs) => crs.id, courses)];
         })
-      )
+      ),
+      'playwright'
     );
 
     // verify everything else is the same
@@ -876,13 +877,14 @@ test.describe('getUserFlowcharts API tests', () => {
     }
 
     // verify course caches are the same
-    verifyCourseCacheStrictEquality(
+    await verifyCourseCacheStrictEquality(
       expCourseCache,
       new Map(
         actCourseCache.map(([catalog, courses]) => {
           return [catalog, new ObjectSet((crs) => crs.id, courses)];
         })
-      )
+      ),
+      'playwright'
     );
 
     // verify everything else is the same

--- a/tests/util/courseCacheUtil.ts
+++ b/tests/util/courseCacheUtil.ts
@@ -1,0 +1,33 @@
+import { expect } from '@playwright/test';
+import { cloneAndDeleteNestedProperty } from 'tests/util/testUtil';
+import type { CourseCache } from '$lib/types';
+
+export function verifyCourseCacheStrictEquality(
+  expCourseCache: CourseCache,
+  actCourseCache: CourseCache
+) {
+  // make sure all catalogs are present
+  expect(Array.from(actCourseCache.keys()).sort()).toStrictEqual(
+    Array.from(expCourseCache.keys()).sort()
+  );
+
+  // for each catalog, expect all courses to be the same
+  expCourseCache.forEach((expCourseCacheEntries, catalog) => {
+    const actCourseCacheEntries = actCourseCache.get(catalog);
+    if (!actCourseCacheEntries) {
+      throw new Error(`actCourseCache entry for catalog ${catalog} missing`);
+    }
+
+    // make sure all courses are present
+    expect(Array.from(actCourseCacheEntries.keys()).sort()).toStrictEqual(
+      Array.from(expCourseCacheEntries.keys()).sort()
+    );
+
+    // now ensure that each course cache entry is correct
+    Array.from(expCourseCacheEntries.values()).forEach((entry) => {
+      expect(
+        cloneAndDeleteNestedProperty(actCourseCacheEntries.get(entry.id), 'dynamicTerms')
+      ).toStrictEqual(cloneAndDeleteNestedProperty(entry, 'dynamicTerms'));
+    });
+  });
+}

--- a/tests/util/storeMocks.ts
+++ b/tests/util/storeMocks.ts
@@ -12,7 +12,7 @@ import type { MajorNameCache, CourseCache } from '$lib/types';
 const mockAvailableFlowchartStartYearsWritable = writable<string[]>([]);
 const mockAvailableFlowchartCatalogsWritable = writable<string[]>([]);
 const mockProgramCacheWritable = writable<Program[]>([]);
-const mockCourseCacheWritable = writable<CourseCache[]>([]);
+const mockCourseCacheWritable = writable<CourseCache>(new Map());
 const mockMajorNameCacheWritable = writable<MajorNameCache[]>([]);
 const mockCatalogMajorNameCacheWritable = writable<Set<string>>(new Set<string>());
 const mockModalOpenWritable = writable<boolean>(false);


### PR DESCRIPTION
part of #11

This PR updates the `CourseCache` type from the existing type of:
```
type CourseCache = {
  catalog: string;
  courses: APICourseFull[];
}[]
```

to a new (more natural) type:
```
type CourseCache = Map<string, ObjectSet<APICourseFull>>;
```

The `ObjectSet` class is introduced, which aims to act as a drop-in replacement for a `Set()` class, but instead works with JavaScript objects non-referentially.

Tests were modified to accommodate this new implementation.