### PR TITLE
feat: update `SearchCache` to use `ObjectMap`

### DIFF
--- a/src/lib/client/stores/catalogSearchStore.ts
+++ b/src/lib/client/stores/catalogSearchStore.ts
@@ -1,5 +1,8 @@
 import { writable } from 'svelte/store';
+import { ObjectMap } from '$lib/common/util/ObjectMap';
 import type { CatalogSearchResults, SearchCache } from '$lib/types';
 
-export const searchCache = writable<SearchCache[]>([]);
+export const searchCache = writable<SearchCache>(
+  new ObjectMap((k) => `${k.catalog}|${k.field}|${k.query}`)
+);
 export const activeSearchResults = writable<Promise<CatalogSearchResults> | undefined>();

--- a/src/lib/common/util/ObjectMap.ts
+++ b/src/lib/common/util/ObjectMap.ts
@@ -1,0 +1,52 @@
+// like a regular Map except the keys can be objects
+// that can be compared non-referentially via the need
+// for a key function to transform K into a string
+export class ObjectMap<K, V> {
+  _map: Map<string, V>;
+  _keyFunction: (input: K) => string;
+
+  constructor(keyFunction: (input: K) => string, items: [K, V][] = []) {
+    this._map = new Map();
+    this._keyFunction = keyFunction;
+
+    for (const [k, v] of items) {
+      this.set(k, v);
+    }
+  }
+
+  get size() {
+    return this._map.size;
+  }
+
+  delete(key: K) {
+    const stringKey = this._keyFunction(key);
+    return this._map.delete(stringKey);
+  }
+
+  entries() {
+    return this._map.entries();
+  }
+
+  get(key: K) {
+    const stringKey = this._keyFunction(key);
+    return this._map.get(stringKey);
+  }
+
+  has(key: K) {
+    const stringKey = this._keyFunction(key);
+    return this._map.has(stringKey);
+  }
+
+  keys() {
+    return this._map.keys();
+  }
+
+  set(key: K, value: V) {
+    const stringKey = this._keyFunction(key);
+    return this._map.set(stringKey, value);
+  }
+
+  values() {
+    return this._map.values();
+  }
+}

--- a/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
@@ -100,9 +100,7 @@
         <div class="loading loading-spinner w-16 text-polyGreen" />
       </div>
     {:then results}
-      {#if results && searchProgramIndex !== -1 && $searchCache
-          .find((entry) => entry.catalog === selectedCatalog)
-          ?.searches.find((searchRecord) => searchRecord.query === `${field}|${transformedQuery}`)}
+      {#if results && searchProgramIndex !== -1 && $searchCache.has( { catalog: String(selectedCatalog), field, query: transformedQuery } )}
         {#if !results.searchValid}
           <div class="text-center">
             <div class="invalidSearchIcon pb-2">

--- a/src/lib/types/courseSearchTypes.ts
+++ b/src/lib/types/courseSearchTypes.ts
@@ -1,3 +1,4 @@
+import type { ObjectMap } from '$lib/common/util/ObjectMap';
 import type { APICourseFull } from '$lib/types';
 
 export interface CatalogSearchResults {
@@ -6,13 +7,16 @@ export interface CatalogSearchResults {
   searchValid: boolean;
 }
 
-// TODO: is this tree structure of the interface necessary?
-export interface SearchCache {
+interface SearchCacheKey {
   catalog: string;
-  searches: {
-    query: string;
-    searchValid: boolean;
-    searchLimitExceeded: boolean;
-    searchResults: string[];
-  }[];
+  field: string;
+  query: string;
 }
+
+interface SearchCacheEntry {
+  searchValid: boolean;
+  searchLimitExceeded: boolean;
+  searchResults: string[];
+}
+
+export type SearchCache = ObjectMap<SearchCacheKey, SearchCacheEntry>;

--- a/src/routes/flows/+page.svelte
+++ b/src/routes/flows/+page.svelte
@@ -4,7 +4,6 @@
   import 'tippy.js/themes/light-border.css';
   import { ObjectSet } from '$lib/common/util/ObjectSet';
   import { FlowViewer } from '$lib/components/Flows';
-  import { searchCache } from '$lib/client/stores/catalogSearchStore.js';
   import { ModalWrapper } from '$lib/components/Flows/modals';
   import { FlowInfoPanel } from '$lib/components/Flows/FlowInfoPanel';
   import { userFlowcharts } from '$lib/client/stores/userDataStore';
@@ -45,10 +44,6 @@
 
   // init local stores
   $: selectedFlowchart = $selectedFlowIndex !== -1 ? $userFlowcharts[$selectedFlowIndex] : null;
-  $: $searchCache = $availableFlowchartCatalogs.map((catalog) => ({
-    catalog,
-    searches: []
-  }));
 
   // TODO: move this logic into the FlowEditor?
   $: {


### PR DESCRIPTION
This PR updates the `SearchCache` type from the following:

```
interface SearchCache {
  catalog: string;
  searches: SearchCacheEntry[];
}[]
```

to the more natural cache type, using the new `ObjectMap`:

```
type SearchCache = ObjectMap<SearchCacheKey, SearchCacheEntry>
```

The new `ObjectMap<K, V>` behaves exactly like a regular `Map<K, V>`, except that objects can be used as keys and be compared for equality non-referentially via a user-passed key function. This makes the cache more ergonomic and natural to use when keying on object types.

Tests were updated to work properly with these changes.