### PR TITLE
feat: improve `ObjectMap` class

### DIFF
--- a/api/src/dev/api-data-bootstrap.ts
+++ b/api/src/dev/api-data-bootstrap.ts
@@ -24,7 +24,7 @@ export const apiData: APIData = {
   startYears: [],
   programData: [],
 
-  courseData: new ObjectMap((k) => `${k.catalog}|${k.id}`),
+  courseData: new ObjectMap(),
   geCourseData: [],
   reqCourseData: []
 };

--- a/src/lib/client/stores/apiDataStore.ts
+++ b/src/lib/client/stores/apiDataStore.ts
@@ -10,6 +10,6 @@ export const availableFlowchartCatalogs = writeOnceStore<string[]>([]);
 
 // API data caches
 export const programCache = writable<Program[]>([]);
-export const courseCache = writable<CourseCache>(new ObjectMap((k) => `${k.catalog}|${k.id}`));
+export const courseCache = writable<CourseCache>(new ObjectMap());
 export const majorNameCache = writable<MajorNameCache[]>([]);
 export const catalogMajorNameCache = writable<Set<string>>(new Set<string>());

--- a/src/lib/client/stores/catalogSearchStore.ts
+++ b/src/lib/client/stores/catalogSearchStore.ts
@@ -2,7 +2,5 @@ import { writable } from 'svelte/store';
 import { ObjectMap } from '$lib/common/util/ObjectMap';
 import type { CatalogSearchResults, SearchCache } from '$lib/types';
 
-export const searchCache = writable<SearchCache>(
-  new ObjectMap((k) => `${k.catalog}|${k.field}|${k.query}`)
-);
+export const searchCache = writable<SearchCache>(new ObjectMap());
 export const activeSearchResults = writable<Promise<CatalogSearchResults> | undefined>();

--- a/src/lib/client/util/unitCounterUtilClient.test.ts
+++ b/src/lib/client/util/unitCounterUtilClient.test.ts
@@ -21,7 +21,7 @@ describe('computeGroupUnits tests', () => {
       total: '0'
     };
 
-    expect(computeGroupUnits(null, new ObjectMap(() => ''), [])).toStrictEqual(expectedCounts);
+    expect(computeGroupUnits(null, new ObjectMap(), [])).toStrictEqual(expectedCounts);
   });
 
   test('standard flowchart, 1 program', () => {
@@ -47,7 +47,7 @@ describe('computeGroupUnits tests', () => {
 
   test('error thrown when unable to find catalog for course', () => {
     expect(() => {
-      computeGroupUnits(TEST_FLOWCHART_SINGLE_PROGRAM_1, new ObjectMap(() => ''), []);
+      computeGroupUnits(TEST_FLOWCHART_SINGLE_PROGRAM_1, new ObjectMap(), []);
     }).toThrowError('could not find catalog for course in flowchart');
   });
 });

--- a/src/lib/common/util/ObjectMap.ts
+++ b/src/lib/common/util/ObjectMap.ts
@@ -15,6 +15,13 @@ export class ObjectMap<K, V> {
 
     if (options.keyFunction) {
       this._keyFunction = options.keyFunction;
+    } else {
+      this._keyFunction = (input: K) => {
+        if (input && typeof input === 'object') {
+          return Object.values(input).join('|');
+        }
+        return String(input);
+      };
     }
 
     if (options.initItems) {

--- a/src/lib/common/util/ObjectMap.ts
+++ b/src/lib/common/util/ObjectMap.ts
@@ -1,16 +1,26 @@
 // like a regular Map except the keys can be objects
 // that can be compared non-referentially via the need
 // for a key function to transform K into a string
+
+interface ObjectMapConstructorOptions<K, V> {
+  keyFunction: (input: K) => string;
+  initItems: [K, V][];
+}
 export class ObjectMap<K, V> {
   _map: Map<string, V>;
   _keyFunction: (input: K) => string;
 
-  constructor(keyFunction: (input: K) => string, items: [K, V][] = []) {
+  constructor(options: Partial<ObjectMapConstructorOptions<K, V>> = {}) {
     this._map = new Map();
-    this._keyFunction = keyFunction;
 
-    for (const [k, v] of items) {
-      this.set(k, v);
+    if (options.keyFunction) {
+      this._keyFunction = options.keyFunction;
+    }
+
+    if (options.initItems) {
+      for (const [k, v] of options.initItems) {
+        this.set(k, v);
+      }
     }
   }
 

--- a/src/lib/common/util/flowDataUtilCommon.test.ts
+++ b/src/lib/common/util/flowDataUtilCommon.test.ts
@@ -261,7 +261,7 @@ describe('generateFlowHash tests', () => {
 
 describe('mergeFlowchartsCourseData tests', () => {
   test('merging with empty data', () => {
-    expect(mergeFlowchartsCourseData([], [], new ObjectMap(() => ''), [])).toEqual([]);
+    expect(mergeFlowchartsCourseData([], [], new ObjectMap(), [])).toEqual([]);
   });
 
   test('merge single flowchart data', () => {

--- a/src/lib/common/util/unitCounterUtilCommon.test.ts
+++ b/src/lib/common/util/unitCounterUtilCommon.test.ts
@@ -320,7 +320,7 @@ describe('computeTotalUnits tests', () => {
   const flowTermData = TEST_FLOWCHART_SINGLE_PROGRAM_1.termData;
 
   test('compute total units for empty flowchart', () => {
-    expect(computeTotalUnits([], new ObjectMap(() => ''), [])).toBe('0');
+    expect(computeTotalUnits([], new ObjectMap(), [])).toBe('0');
   });
 
   test('compute total units for standard flowchart, no fullCompute', () => {

--- a/src/lib/server/config/apiDataConfig.ts
+++ b/src/lib/server/config/apiDataConfig.ts
@@ -11,7 +11,7 @@ export const apiData: APIData = {
   startYears: [],
   programData: [],
 
-  courseData: new ObjectMap((k) => `${k.catalog}|${k.id}`),
+  courseData: new ObjectMap(),
   geCourseData: [],
   reqCourseData: []
 };

--- a/src/lib/server/util/courseCacheUtil.ts
+++ b/src/lib/server/util/courseCacheUtil.ts
@@ -21,7 +21,7 @@ export async function generateCourseCacheFlowcharts(
   // for merge use cases e.g. generateFlowchart
   enforceUniqueCoursesAcrossCaches = false
 ): Promise<CourseCache> {
-  const flowchartCourseCache: CourseCache = new ObjectMap((k) => `${k.catalog}|${k.id}`);
+  const flowchartCourseCache: CourseCache = new ObjectMap();
 
   // only keep the IDs in here vs. the entire course object so === equality works properly
   const courseCatalogAndIds = new Set<string>();
@@ -88,7 +88,7 @@ export async function generateCourseCacheFromUpdateChunks(
   chunksList: UserDataUpdateChunk[],
   programCache: Program[]
 ): Promise<CourseCache | undefined> {
-  const flowchartCourseCache: CourseCache = new ObjectMap((k) => `${k.catalog}|${k.id}`);
+  const flowchartCourseCache: CourseCache = new ObjectMap();
 
   // only keep the IDs in here vs. the entire course object so === equality works properly
   const courseCatalogAndIds = new Set<string>();

--- a/src/routes/flows/+page.svelte
+++ b/src/routes/flows/+page.svelte
@@ -34,9 +34,8 @@
   // API data caches
   courseCache.set(
     // deserialize course cache
-    new ObjectMap(
-      (k) => `${k.catalog}|${k.id}`,
-      data.userData.courseCache.map(([k, v]) => {
+    new ObjectMap({
+      initItems: data.userData.courseCache.map(([k, v]) => {
         const [catalog, id] = k.split('|');
         return [
           {
@@ -46,7 +45,7 @@
           v
         ];
       })
-    )
+    })
   );
   programCache.set(data.userData.programMetadata);
 

--- a/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
+++ b/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
@@ -454,9 +454,8 @@ test.describe('generate flowchart api output tests', () => {
       ]),
       // deserialize course cache
       courseCache: resData.courseCache
-        ? new ObjectMap(
-            (k) => `${k.catalog}|${k.id}`,
-            resData.courseCache.map(([k, v]) => {
+        ? new ObjectMap({
+            initItems: resData.courseCache.map(([k, v]) => {
               const [catalog, id] = k.split('|');
               return [
                 {
@@ -466,7 +465,7 @@ test.describe('generate flowchart api output tests', () => {
                 v
               ];
             })
-          )
+          })
         : undefined
     };
 
@@ -545,9 +544,8 @@ test.describe('generate flowchart api output tests', () => {
     resData.generatedFlowchart.lastUpdatedUTC = new Date(resData.generatedFlowchart.lastUpdatedUTC);
 
     // remove GE courses from expected payload
-    const expCourseCacheNoGE = new ObjectMap(
-      (k) => `${k.catalog}|${k.id}`,
-      resData.courseCache?.map(([k, v]) => {
+    const expCourseCacheNoGE = new ObjectMap({
+      initItems: resData.courseCache?.map(([k, v]) => {
         const [catalog, id] = k.split('|');
         return [
           {
@@ -557,7 +555,7 @@ test.describe('generate flowchart api output tests', () => {
           v
         ];
       })
-    );
+    });
     expCourseCacheNoGE.delete({
       catalog: '2015-2017',
       id: 'ENGL134'
@@ -590,9 +588,8 @@ test.describe('generate flowchart api output tests', () => {
       ]),
       // deserialize course cache
       courseCache: resData.courseCache
-        ? new ObjectMap(
-            (k) => `${k.catalog}|${k.id}`,
-            resData.courseCache.map(([k, v]) => {
+        ? new ObjectMap({
+            initItems: resData.courseCache.map(([k, v]) => {
               const [catalog, id] = k.split('|');
               return [
                 {
@@ -602,7 +599,7 @@ test.describe('generate flowchart api output tests', () => {
                 v
               ];
             })
-          )
+          })
         : undefined
     };
 
@@ -660,9 +657,8 @@ test.describe('generate flowchart api output tests', () => {
       ]),
       // deserialize course cache
       courseCache: resData.courseCache
-        ? new ObjectMap(
-            (k) => `${k.catalog}|${k.id}`,
-            resData.courseCache.map(([k, v]) => {
+        ? new ObjectMap({
+            initItems: resData.courseCache.map(([k, v]) => {
               const [catalog, id] = k.split('|');
               return [
                 {
@@ -672,7 +668,7 @@ test.describe('generate flowchart api output tests', () => {
                 v
               ];
             })
-          )
+          })
         : undefined
     };
 
@@ -732,9 +728,8 @@ test.describe('generate flowchart api output tests', () => {
       ]),
       // deserialize course cache
       courseCache: resData.courseCache
-        ? new ObjectMap(
-            (k) => `${k.catalog}|${k.id}`,
-            resData.courseCache.map(([k, v]) => {
+        ? new ObjectMap({
+            initItems: resData.courseCache.map(([k, v]) => {
               const [catalog, id] = k.split('|');
               return [
                 {
@@ -744,7 +739,7 @@ test.describe('generate flowchart api output tests', () => {
                 v
               ];
             })
-          )
+          })
         : undefined
     };
 

--- a/tests/api/getUserFlowchartsTests.test.ts
+++ b/tests/api/getUserFlowchartsTests.test.ts
@@ -328,9 +328,8 @@ test.describe('getUserFlowcharts API tests', () => {
     // verify course caches are the same
     await verifyCourseCacheStrictEquality(
       expCourseCache,
-      new ObjectMap(
-        (k) => `${k.catalog}|${k.id}`,
-        actCourseCache.map(([k, v]) => {
+      new ObjectMap({
+        initItems: actCourseCache.map(([k, v]) => {
           const [catalog, id] = k.split('|');
           return [
             {
@@ -340,7 +339,7 @@ test.describe('getUserFlowcharts API tests', () => {
             v
           ];
         })
-      ),
+      }),
       'playwright'
     );
 
@@ -858,9 +857,8 @@ test.describe('getUserFlowcharts API tests', () => {
     // verify course caches are the same
     await verifyCourseCacheStrictEquality(
       expCourseCache,
-      new ObjectMap(
-        (k) => `${k.catalog}|${k.id}`,
-        actCourseCache.map(([k, v]) => {
+      new ObjectMap({
+        initItems: actCourseCache.map(([k, v]) => {
           const [catalog, id] = k.split('|');
           return [
             {
@@ -870,7 +868,7 @@ test.describe('getUserFlowcharts API tests', () => {
             v
           ];
         })
-      ),
+      }),
       'playwright'
     );
 

--- a/tests/util/courseCacheUtil.ts
+++ b/tests/util/courseCacheUtil.ts
@@ -44,14 +44,13 @@ export async function verifyCourseCacheStrictEquality(
 }
 
 export function createCourseCacheFromEntries(entries: APICourseFull[]): CourseCache {
-  return new ObjectMap(
-    (k) => `${k.catalog}|${k.id}`,
-    entries.map((entry) => [
+  return new ObjectMap({
+    initItems: entries.map((entry) => [
       {
         catalog: entry.catalog,
         id: entry.id
       },
       entry
     ])
-  );
+  });
 }

--- a/tests/util/storeMocks.ts
+++ b/tests/util/storeMocks.ts
@@ -13,7 +13,7 @@ import type { MajorNameCache, CourseCache } from '$lib/types';
 const mockAvailableFlowchartStartYearsWritable = writable<string[]>([]);
 const mockAvailableFlowchartCatalogsWritable = writable<string[]>([]);
 const mockProgramCacheWritable = writable<Program[]>([]);
-const mockCourseCacheWritable = writable<CourseCache>(new ObjectMap((k) => `${k.catalog}|${k.id}`));
+const mockCourseCacheWritable = writable<CourseCache>(new ObjectMap());
 const mockMajorNameCacheWritable = writable<MajorNameCache[]>([]);
 const mockCatalogMajorNameCacheWritable = writable<Set<string>>(new Set<string>());
 const mockModalOpenWritable = writable<boolean>(false);


### PR DESCRIPTION
This PR improves the newly introduced `ObjectMap` class in the following ways:

1. add a default `keyFunction`, which will compute the key string based on sorted input properties if the input is a `Record<string, unknown>` type, or simply convert the input to a string otherwise.
2. change the `ObjectMap` constructor interface to `Partial<ObjectMapConstructorOptions>`, which is more ergonomic if we want to add more configuration options to the `ObjectMap` in the future.

Consumers of the `ObjectMap` were updated for this new functionality, and tests were updated to pass with these changes.