### PR TITLE
feat: improve CourseCache serialization and deserialization performance

### DIFF
--- a/src/lib/components/Flows/modals/NewFlowModal.svelte
+++ b/src/lib/components/Flows/modals/NewFlowModal.svelte
@@ -51,7 +51,7 @@
       case 200: {
         const respJson = (await resp.json()) as {
           generatedFlowchart: Flowchart;
-          courseCache: [string, APICourseFull][];
+          courseCache: APICourseFull[];
         };
         persistNewFlowchart(respJson);
         break;
@@ -73,19 +73,18 @@
 
   function persistNewFlowchart(res: {
     generatedFlowchart: Flowchart;
-    courseCache: [string, APICourseFull][];
+    courseCache: APICourseFull[];
   }) {
     // TODO: empty flowchart case
 
     // merge returned cache with existing
-    const newCourseCacheEntries = res.courseCache.map(([k, v]) => {
-      const [catalog, id] = k.split('|');
+    const newCourseCacheEntries = res.courseCache.map((entry) => {
       return [
         {
-          catalog,
-          id
+          catalog: entry.catalog,
+          id: entry.id
         },
-        v
+        entry
       ] as [CourseCacheKey, APICourseFull];
     });
     newCourseCacheEntries.forEach(([k, v]) => {

--- a/src/routes/api/user/data/getUserFlowcharts/+server.ts
+++ b/src/routes/api/user/data/getUserFlowcharts/+server.ts
@@ -58,7 +58,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
         ...(parseResults.data.includeCourseCache && {
           // serialize course cache
           courseCache: Array.from(
-            (await generateCourseCacheFlowcharts(flowcharts, programMetadata)).entries()
+            (await generateCourseCacheFlowcharts(flowcharts, programMetadata)).values()
           )
         }),
         ...(parseResults.data.includeProgramMetadata && {

--- a/src/routes/api/util/generateFlowchart/+server.ts
+++ b/src/routes/api/util/generateFlowchart/+server.ts
@@ -82,7 +82,7 @@ export const GET: RequestHandler = async ({ locals, url }) => {
         generatedFlowchart,
         ...(parseResults.data.generateCourseCache && {
           // serialize course cache
-          courseCache: Array.from(courseCache.entries())
+          courseCache: Array.from(courseCache.values())
         })
       });
     } else {

--- a/src/routes/flows/+page.server.ts
+++ b/src/routes/flows/+page.server.ts
@@ -11,7 +11,7 @@ export const load: PageServerLoad = (event) => {
 
   async function fetchUserData(): Promise<{
     flowcharts: Flowchart[];
-    courseCache: [string, APICourseFull][];
+    courseCache: APICourseFull[];
     programMetadata: Program[];
   }> {
     const data = await event.fetch(
@@ -20,7 +20,7 @@ export const load: PageServerLoad = (event) => {
 
     const dataJson = (await data.json()) as {
       flowcharts: Flowchart[];
-      courseCache: [string, APICourseFull][];
+      courseCache: APICourseFull[];
       programMetadata: Program[];
       message: string;
     };

--- a/src/routes/flows/+page.svelte
+++ b/src/routes/flows/+page.svelte
@@ -35,14 +35,13 @@
   courseCache.set(
     // deserialize course cache
     new ObjectMap({
-      initItems: data.userData.courseCache.map(([k, v]) => {
-        const [catalog, id] = k.split('|');
+      initItems: data.userData.courseCache.map((entry) => {
         return [
           {
-            catalog,
-            id
+            catalog: entry.catalog,
+            id: entry.id
           },
-          v
+          entry
         ];
       })
     })

--- a/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
+++ b/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
@@ -19,7 +19,7 @@ import type { APICourseFull } from '$lib/types/apiDataTypes';
 interface GenerateFlowchartExpectedReturnType {
   message: string;
   generatedFlowchart: Flowchart;
-  courseCache: [string, APICourseFull][] | undefined;
+  courseCache: APICourseFull[] | undefined;
 }
 
 test.describe('generate flowchart api input tests', () => {
@@ -455,14 +455,13 @@ test.describe('generate flowchart api output tests', () => {
       // deserialize course cache
       courseCache: resData.courseCache
         ? new ObjectMap({
-            initItems: resData.courseCache.map(([k, v]) => {
-              const [catalog, id] = k.split('|');
+            initItems: resData.courseCache.map((entry) => {
               return [
                 {
-                  catalog,
-                  id
+                  catalog: entry.catalog,
+                  id: entry.id
                 },
-                v
+                entry
               ];
             })
           })
@@ -545,14 +544,13 @@ test.describe('generate flowchart api output tests', () => {
 
     // remove GE courses from expected payload
     const expCourseCacheNoGE = new ObjectMap({
-      initItems: resData.courseCache?.map(([k, v]) => {
-        const [catalog, id] = k.split('|');
+      initItems: resData.courseCache?.map((entry) => {
         return [
           {
-            catalog,
-            id
+            catalog: entry.catalog,
+            id: entry.id
           },
-          v
+          entry
         ];
       })
     });
@@ -589,14 +587,13 @@ test.describe('generate flowchart api output tests', () => {
       // deserialize course cache
       courseCache: resData.courseCache
         ? new ObjectMap({
-            initItems: resData.courseCache.map(([k, v]) => {
-              const [catalog, id] = k.split('|');
+            initItems: resData.courseCache.map((entry) => {
               return [
                 {
-                  catalog,
-                  id
+                  catalog: entry.catalog,
+                  id: entry.id
                 },
-                v
+                entry
               ];
             })
           })
@@ -658,14 +655,13 @@ test.describe('generate flowchart api output tests', () => {
       // deserialize course cache
       courseCache: resData.courseCache
         ? new ObjectMap({
-            initItems: resData.courseCache.map(([k, v]) => {
-              const [catalog, id] = k.split('|');
+            initItems: resData.courseCache.map((entry) => {
               return [
                 {
-                  catalog,
-                  id
+                  catalog: entry.catalog,
+                  id: entry.id
                 },
-                v
+                entry
               ];
             })
           })
@@ -729,14 +725,13 @@ test.describe('generate flowchart api output tests', () => {
       // deserialize course cache
       courseCache: resData.courseCache
         ? new ObjectMap({
-            initItems: resData.courseCache.map(([k, v]) => {
-              const [catalog, id] = k.split('|');
+            initItems: resData.courseCache.map((entry) => {
               return [
                 {
-                  catalog,
-                  id
+                  catalog: entry.catalog,
+                  id: entry.id
                 },
-                v
+                entry
               ];
             })
           })

--- a/tests/api/getUserFlowchartsTests.test.ts
+++ b/tests/api/getUserFlowchartsTests.test.ts
@@ -16,7 +16,7 @@ import type { APICourseFull } from '$lib/types';
 interface GetUserFlowchartsExpectedReturnType {
   message: string;
   flowcharts: Flowchart[];
-  courseCache: [string, APICourseFull][] | undefined;
+  courseCache: APICourseFull[] | undefined;
 }
 
 test.describe('getUserFlowcharts API tests', () => {
@@ -329,14 +329,13 @@ test.describe('getUserFlowcharts API tests', () => {
     await verifyCourseCacheStrictEquality(
       expCourseCache,
       new ObjectMap({
-        initItems: actCourseCache.map(([k, v]) => {
-          const [catalog, id] = k.split('|');
+        initItems: actCourseCache.map((entry) => {
           return [
             {
-              catalog,
-              id
+              catalog: entry.catalog,
+              id: entry.id
             },
-            v
+            entry
           ];
         })
       }),
@@ -858,14 +857,13 @@ test.describe('getUserFlowcharts API tests', () => {
     await verifyCourseCacheStrictEquality(
       expCourseCache,
       new ObjectMap({
-        initItems: actCourseCache.map(([k, v]) => {
-          const [catalog, id] = k.split('|');
+        initItems: actCourseCache.map((entry) => {
           return [
             {
-              catalog,
-              id
+              catalog: entry.catalog,
+              id: entry.id
             },
-            v
+            entry
           ];
         })
       }),


### PR DESCRIPTION
This PR improves the serde performance of transmitting `CourseCache` entries across the network.

Previously, we were sending both the key and value (`CourseCacheKey` and `APICourseFull`) for each entry in the cache. However, since the `CourseCacheKey` can be directly derived from the corresponding `APICourseFull` entry, sending the `CourseCacheKey` across the network is redundant and wasteful.

So, we now only send the `APICourseFull` entry across the network and reconstruct the `CourseCacheKey` when adding these courses to the client-side `CourseCache`.

Tests were updated to accommodate these changes.