### PR TITLE
feat: improve `getCatalogFromProgramIDIndex`

### DIFF
--- a/src/lib/client/util/courseItemUtil.ts
+++ b/src/lib/client/util/courseItemUtil.ts
@@ -36,6 +36,12 @@ export function buildTermCourseItemsData(
       courseCache,
       programCache
     );
+    if (course.id && !courseMetadata) {
+      throw new Error(
+        `buildTermCourseItemsData: unable to find course metadata for course ${course.id}`
+      );
+    }
+
     const computedCourseDisplayValues = computeCourseDisplayValues(course, courseMetadata);
 
     const itemData: CourseItemData = {

--- a/src/lib/client/util/unitCounterUtilClient.test.ts
+++ b/src/lib/client/util/unitCounterUtilClient.test.ts
@@ -26,7 +26,7 @@ describe('computeGroupUnits tests', () => {
 
   test('standard flowchart, 1 program', () => {
     const expectedCounts = {
-      major: '118-119',
+      major: '132-133',
       support: '0',
       conc1: '0',
       conc2: '0',
@@ -45,9 +45,9 @@ describe('computeGroupUnits tests', () => {
     ).toStrictEqual(expectedCounts);
   });
 
-  test('error thrown when unable to find catalog for course', () => {
+  test('error thrown when unable to find course metadata entry', () => {
     expect(() => {
       computeGroupUnits(TEST_FLOWCHART_SINGLE_PROGRAM_1, new ObjectMap(), new Map());
-    }).toThrowError('could not find catalog for course in flowchart');
+    }).toThrowError('unitCounterUtilClient: unable to locate course metadata for course AGC102');
   });
 });

--- a/src/lib/client/util/unitCounterUtilClient.ts
+++ b/src/lib/client/util/unitCounterUtilClient.ts
@@ -1,7 +1,6 @@
 import { COLORS } from '$lib/common/config/colorConfig';
 import { SANITIZE_REGEX } from '$lib/common/config/catalogSearchConfig';
 import { incrementRangedUnits } from '$lib/common/util/unitCounterUtilCommon';
-import { getCatalogFromProgramID } from '$lib/common/util/flowDataUtilCommon';
 import { getCourseFromCourseCache } from '$lib/common/util/courseDataUtilCommon';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache, FlowEditorFooterUnitCounts, ProgramCache } from '$lib/types';
@@ -35,23 +34,18 @@ export function computeGroupUnits(
   // iterate over all courses
   flowchart.termData.forEach((term) => {
     term.courses.forEach((course) => {
-      // perform lookup if necessary
-      const courseCatalog = getCatalogFromProgramID(
-        flowchart.programId,
-        course.programIdIndex,
-        programCache
-      );
-
-      if (!courseCatalog) {
-        throw new Error('could not find catalog for course in flowchart');
-      }
-
+      // perform lookup to get unit counts
       const courseMetadata = getCourseFromCourseCache(
         course,
         flowchart.programId,
         courseCache,
         programCache
       );
+      if (course.id && !courseMetadata) {
+        throw new Error(
+          `unitCounterUtilClient: unable to locate course metadata for course ${course.id}`
+        );
+      }
 
       // customUnits takes precedence even if we have a standard course
       // (for standard+customUnit cases)

--- a/src/lib/client/util/unitCounterUtilClient.ts
+++ b/src/lib/client/util/unitCounterUtilClient.ts
@@ -39,7 +39,7 @@ export function computeGroupUnits(
     term.courses.forEach((course) => {
       // perform lookup if necessary
       const courseCatalog = getCatalogFromProgramIDIndex(
-        course.programIdIndex ?? 0,
+        course.programIdIndex,
         flowchart.programId,
         programCache
       );

--- a/src/lib/client/util/unitCounterUtilClient.ts
+++ b/src/lib/client/util/unitCounterUtilClient.ts
@@ -1,10 +1,8 @@
 import { COLORS } from '$lib/common/config/colorConfig';
 import { SANITIZE_REGEX } from '$lib/common/config/catalogSearchConfig';
 import { incrementRangedUnits } from '$lib/common/util/unitCounterUtilCommon';
-import {
-  getCourseFromCourseCache,
-  getCatalogFromProgramIDIndex
-} from '$lib/common/util/courseDataUtilCommon';
+import { getCatalogFromProgramID } from '$lib/common/util/flowDataUtilCommon';
+import { getCourseFromCourseCache } from '$lib/common/util/courseDataUtilCommon';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache, FlowEditorFooterUnitCounts, ProgramCache } from '$lib/types';
 
@@ -38,9 +36,9 @@ export function computeGroupUnits(
   flowchart.termData.forEach((term) => {
     term.courses.forEach((course) => {
       // perform lookup if necessary
-      const courseCatalog = getCatalogFromProgramIDIndex(
-        course.programIdIndex,
+      const courseCatalog = getCatalogFromProgramID(
         flowchart.programId,
+        course.programIdIndex,
         programCache
       );
 

--- a/src/lib/common/util/courseDataUtilCommon.test.ts
+++ b/src/lib/common/util/courseDataUtilCommon.test.ts
@@ -1,70 +1,10 @@
 import * as apiDataConfig from '$lib/server/config/apiDataConfig';
-import {
-  computeCourseDisplayValues,
-  getCatalogFromProgramIDIndex
-} from '$lib/common/util/courseDataUtilCommon';
+import { computeCourseDisplayValues } from '$lib/common/util/courseDataUtilCommon';
+import type { Course } from '$lib/common/schema/flowchartSchema';
 import type { APICourseFull, ComputedCourseItemDisplayData } from '$lib/types';
-import type { Course } from '../schema/flowchartSchema';
 
 // init API data
 await apiDataConfig.init();
-
-describe('courseDataUtilCommon tests', () => {
-  test('valid catalog with one program', () => {
-    const catalog = getCatalogFromProgramIDIndex(
-      0,
-      ['d38fef1b-990b-4cce-a82c-79d55879f4be'],
-      apiDataConfig.apiData.programData
-    );
-    expect(catalog).toBe('2022-2026');
-  });
-
-  test('valid catalog with two programs', () => {
-    const programs = [
-      '1c3a7751-0eb8-4652-b316-0307f1db312f',
-      '0e7e23c6-aeee-418d-93f7-5ba3475ab00b'
-    ];
-    expect(getCatalogFromProgramIDIndex(0, programs, apiDataConfig.apiData.programData)).toBe(
-      '2019-2020'
-    );
-    expect(getCatalogFromProgramIDIndex(1, programs, apiDataConfig.apiData.programData)).toBe(
-      '2020-2021'
-    );
-  });
-
-  test('valid catalog with max number of programs', () => {
-    const programs = [
-      '1c3a7751-0eb8-4652-b316-0307f1db312f',
-      '0e7e23c6-aeee-418d-93f7-5ba3475ab00b',
-      '3f289773-7b54-4d99-8e03-48c829b63636',
-      '10ee525b-780d-4aa8-8a91-be6498c89937',
-      'bf13b9db-acc0-4967-bd9e-f123693652e5'
-    ];
-    expect(getCatalogFromProgramIDIndex(4, programs, apiDataConfig.apiData.programData)).toBe(
-      '2019-2020'
-    );
-    expect(getCatalogFromProgramIDIndex(2, programs, apiDataConfig.apiData.programData)).toBe(
-      '2015-2017'
-    );
-  });
-
-  test('undefined catalog', () => {
-    const programs = [
-      '1c3a7751-0eb8-4652-b316-0307f1db312f',
-      '0e7e23c6-aeee-418d-93f7-5ba3475ab00b',
-      '3f289773-7b54-4d99-8e03-48c829b63636',
-      '10ee525b-780d-4aa8-8a91-be6498c89937',
-      'bf13b9db-acc0-4967-bd9e-f123693652e5'
-    ];
-    expect(
-      getCatalogFromProgramIDIndex(-1, programs, apiDataConfig.apiData.programData)
-    ).toBeUndefined();
-    expect(
-      getCatalogFromProgramIDIndex(5, programs, apiDataConfig.apiData.programData)
-    ).toBeUndefined();
-    expect(getCatalogFromProgramIDIndex(3, programs, new Map())).toBeUndefined();
-  });
-});
 
 describe('computeCourseDisplayValues tests', () => {
   const courseMetadata: APICourseFull = {

--- a/src/lib/common/util/courseDataUtilCommon.ts
+++ b/src/lib/common/util/courseDataUtilCommon.ts
@@ -31,11 +31,11 @@ export function getCourseFromCourseCache(
 }
 
 export function getCatalogFromProgramIDIndex(
-  programIDIndex: number,
+  programIDIndex: number | undefined,
   programId: string[],
   programCache: ProgramCache
 ): string | undefined {
-  return programCache.get(programId[programIDIndex])?.catalog;
+  return programCache.get(programId[programIDIndex ?? 0])?.catalog;
 }
 
 export function computeCourseDisplayValues(

--- a/src/lib/common/util/courseDataUtilCommon.ts
+++ b/src/lib/common/util/courseDataUtilCommon.ts
@@ -1,5 +1,6 @@
 // handles common functionality with course data
 
+import { getCatalogFromProgramID } from './flowDataUtilCommon';
 import type { Course } from '$lib/common/schema/flowchartSchema';
 import type {
   CourseCache,
@@ -14,7 +15,7 @@ export function getCourseFromCourseCache(
   courseCache: CourseCache,
   programCache: ProgramCache
 ) {
-  const catalog = getCatalogFromProgramIDIndex(course.programIdIndex, flowProgramId, programCache);
+  const catalog = getCatalogFromProgramID(flowProgramId, course.programIdIndex, programCache);
   const courseMetadata =
     !course.id || !catalog
       ? null

--- a/src/lib/common/util/courseDataUtilCommon.ts
+++ b/src/lib/common/util/courseDataUtilCommon.ts
@@ -1,6 +1,6 @@
 // handles common functionality with course data
 
-import { getCatalogFromProgramID } from './flowDataUtilCommon';
+import { getCatalogFromProgramID } from '$lib/common/util/flowDataUtilCommon';
 import type { Course } from '$lib/common/schema/flowchartSchema';
 import type {
   CourseCache,

--- a/src/lib/common/util/courseDataUtilCommon.ts
+++ b/src/lib/common/util/courseDataUtilCommon.ts
@@ -14,11 +14,7 @@ export function getCourseFromCourseCache(
   courseCache: CourseCache,
   programCache: ProgramCache
 ) {
-  const catalog = getCatalogFromProgramIDIndex(
-    course.programIdIndex ?? 0,
-    flowProgramId,
-    programCache
-  );
+  const catalog = getCatalogFromProgramIDIndex(course.programIdIndex, flowProgramId, programCache);
   const courseMetadata =
     !course.id || !catalog
       ? null

--- a/src/lib/common/util/courseDataUtilCommon.ts
+++ b/src/lib/common/util/courseDataUtilCommon.ts
@@ -26,14 +26,6 @@ export function getCourseFromCourseCache(
   return courseMetadata;
 }
 
-export function getCatalogFromProgramIDIndex(
-  programIDIndex: number | undefined,
-  programId: string[],
-  programCache: ProgramCache
-): string | undefined {
-  return programCache.get(programId[programIDIndex ?? 0])?.catalog;
-}
-
 export function computeCourseDisplayValues(
   course: Course,
   courseMetadata: APICourseFull | null,

--- a/src/lib/common/util/flowDataUtilCommon.test.ts
+++ b/src/lib/common/util/flowDataUtilCommon.test.ts
@@ -1,11 +1,70 @@
 import * as apiDataConfig from '$lib/server/config/apiDataConfig';
 import { ObjectMap } from '$lib/common/util/ObjectMap';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
-import { generateFlowHash, mergeFlowchartsCourseData } from '$lib/common/util/flowDataUtilCommon';
+import {
+  generateFlowHash,
+  getCatalogFromProgramID,
+  mergeFlowchartsCourseData
+} from '$lib/common/util/flowDataUtilCommon';
 import type { Flowchart, Term } from '$lib/common/schema/flowchartSchema';
 
 // init API data
 await apiDataConfig.init();
+
+describe('getCatalogFromProgramID tests', () => {
+  test('valid catalog with one program', () => {
+    const catalog = getCatalogFromProgramID(
+      ['d38fef1b-990b-4cce-a82c-79d55879f4be'],
+      0,
+      apiDataConfig.apiData.programData
+    );
+    expect(catalog).toBe('2022-2026');
+  });
+
+  test('valid catalog with two programs', () => {
+    const programs = [
+      '1c3a7751-0eb8-4652-b316-0307f1db312f',
+      '0e7e23c6-aeee-418d-93f7-5ba3475ab00b'
+    ];
+    expect(getCatalogFromProgramID(programs, 0, apiDataConfig.apiData.programData)).toBe(
+      '2019-2020'
+    );
+    expect(getCatalogFromProgramID(programs, 1, apiDataConfig.apiData.programData)).toBe(
+      '2020-2021'
+    );
+  });
+
+  test('valid catalog with max number of programs', () => {
+    const programs = [
+      '1c3a7751-0eb8-4652-b316-0307f1db312f',
+      '0e7e23c6-aeee-418d-93f7-5ba3475ab00b',
+      '3f289773-7b54-4d99-8e03-48c829b63636',
+      '10ee525b-780d-4aa8-8a91-be6498c89937',
+      'bf13b9db-acc0-4967-bd9e-f123693652e5'
+    ];
+    expect(getCatalogFromProgramID(programs, 4, apiDataConfig.apiData.programData)).toBe(
+      '2019-2020'
+    );
+    expect(getCatalogFromProgramID(programs, 2, apiDataConfig.apiData.programData)).toBe(
+      '2015-2017'
+    );
+  });
+
+  test('undefined catalog', () => {
+    const programs = [
+      '1c3a7751-0eb8-4652-b316-0307f1db312f',
+      '0e7e23c6-aeee-418d-93f7-5ba3475ab00b',
+      '3f289773-7b54-4d99-8e03-48c829b63636',
+      '10ee525b-780d-4aa8-8a91-be6498c89937',
+      'bf13b9db-acc0-4967-bd9e-f123693652e5'
+    ];
+    expect(
+      getCatalogFromProgramID(programs, -1, apiDataConfig.apiData.programData)
+    ).toBeUndefined();
+    expect(getCatalogFromProgramID(programs, 5, apiDataConfig.apiData.programData)).toBeUndefined();
+    expect(getCatalogFromProgramID(programs, 3, new Map())).toBeUndefined();
+  });
+});
 
 describe('generateFlowHash tests', () => {
   test('hash works', () => {

--- a/src/lib/common/util/flowDataUtilCommon.ts
+++ b/src/lib/common/util/flowDataUtilCommon.ts
@@ -112,3 +112,12 @@ export function mergeFlowchartsCourseData(
 
   return mergedFlowchartsTermData;
 }
+
+// wrapper function to extract catalog from program ID
+export function getCatalogFromProgramID(
+  programId: string[],
+  programIDIndex: number | undefined,
+  programCache: ProgramCache
+): string | undefined {
+  return programCache.get(programId[programIDIndex ?? 0])?.catalog;
+}

--- a/src/lib/common/util/unitCounterUtilCommon.test.ts
+++ b/src/lib/common/util/unitCounterUtilCommon.test.ts
@@ -257,7 +257,7 @@ describe('computeTermUnits tests', () => {
     ).toBe('21-26');
   });
 
-  test('computeTermUnits unable to find course catalog', () => {
+  test('computeTermUnits unable to find course metadata', () => {
     const termData: Course[] = [
       {
         color: '#FEFD9A',
@@ -280,7 +280,7 @@ describe('computeTermUnits tests', () => {
         apiDataConfig.apiData.courseData,
         apiDataConfig.apiData.programData
       )
-    ).toThrowError('unitCounterUtil: undefined courseCatalog');
+    ).toThrowError('unitCounterUtil: unable to find course metadata for course AGC301');
   });
 
   test('computeTermUnits unable to find course metadata', () => {

--- a/src/lib/common/util/unitCounterUtilCommon.ts
+++ b/src/lib/common/util/unitCounterUtilCommon.ts
@@ -1,9 +1,7 @@
 // util functions related to unit counting
 
-import {
-  getCourseFromCourseCache,
-  getCatalogFromProgramIDIndex
-} from '$lib/common/util/courseDataUtilCommon';
+import { getCatalogFromProgramID } from '$lib/common/util/flowDataUtilCommon';
+import { getCourseFromCourseCache } from '$lib/common/util/courseDataUtilCommon';
 import type { Course, Term } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache, ProgramCache } from '$lib/types';
 
@@ -34,7 +32,7 @@ export function computeTermUnits(
       computedTermUnits = incrementRangedUnits(computedTermUnits, c.customUnits);
     } else if (c.id) {
       // select the correct catalog
-      const courseCatalog = getCatalogFromProgramIDIndex(c.programIdIndex, programId, programCache);
+      const courseCatalog = getCatalogFromProgramID(programId, c.programIdIndex, programCache);
       if (!courseCatalog) {
         throw new Error('unitCounterUtil: undefined courseCatalog');
       }

--- a/src/lib/common/util/unitCounterUtilCommon.ts
+++ b/src/lib/common/util/unitCounterUtilCommon.ts
@@ -34,11 +34,7 @@ export function computeTermUnits(
       computedTermUnits = incrementRangedUnits(computedTermUnits, c.customUnits);
     } else if (c.id) {
       // select the correct catalog
-      const courseCatalog = getCatalogFromProgramIDIndex(
-        c.programIdIndex ?? 0,
-        programId,
-        programCache
-      );
+      const courseCatalog = getCatalogFromProgramIDIndex(c.programIdIndex, programId, programCache);
       if (!courseCatalog) {
         throw new Error('unitCounterUtil: undefined courseCatalog');
       }

--- a/src/lib/common/util/unitCounterUtilCommon.ts
+++ b/src/lib/common/util/unitCounterUtilCommon.ts
@@ -1,6 +1,5 @@
 // util functions related to unit counting
 
-import { getCatalogFromProgramID } from '$lib/common/util/flowDataUtilCommon';
 import { getCourseFromCourseCache } from '$lib/common/util/courseDataUtilCommon';
 import type { Course, Term } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache, ProgramCache } from '$lib/types';
@@ -31,11 +30,6 @@ export function computeTermUnits(
     if (c.customUnits) {
       computedTermUnits = incrementRangedUnits(computedTermUnits, c.customUnits);
     } else if (c.id) {
-      // select the correct catalog
-      const courseCatalog = getCatalogFromProgramID(programId, c.programIdIndex, programCache);
-      if (!courseCatalog) {
-        throw new Error('unitCounterUtil: undefined courseCatalog');
-      }
       const courseMetadata = getCourseFromCourseCache(c, programId, courseCache, programCache);
       if (!courseMetadata) {
         throw new Error(`unitCounterUtil: unable to find course metadata for course ${c.id}`);

--- a/src/lib/components/Flows/FlowEditor/TermContainer.test.ts
+++ b/src/lib/components/Flows/FlowEditor/TermContainer.test.ts
@@ -1,11 +1,33 @@
-import TermContainer from './TermContainer.svelte';
+import * as apiDataConfig from '$lib/server/config/apiDataConfig';
 import { render, screen } from '@testing-library/svelte';
 import { TEST_FLOWCHART_SINGLE_PROGRAM_2 } from '../../../../../tests/util/testFlowcharts';
+import { mockCourseCacheStore, mockProgramCacheStore } from '../../../../../tests/util/storeMocks';
+
+// load necessary API data
+await apiDataConfig.init();
 
 const TEST_TERM_EMPTY = TEST_FLOWCHART_SINGLE_PROGRAM_2.termData[0];
 const TEST_TERM_COURSES = TEST_FLOWCHART_SINGLE_PROGRAM_2.termData[1];
 
+// this import NEEDS to be down here or else the vi.mock() call that we're using to mock
+// the programCache and courseCache stores FAILS!! because vi.mock() MUST be called
+// before the TermContainer component is imported or else things break
+import TermContainer from './TermContainer.svelte';
+
 describe('TermContainer component tests', () => {
+  // need to mock out relevant stores since TermContainer depends on these
+  // mock call is hoisted to top of file
+  beforeAll(() => {
+    vi.mock('$lib/client/stores/apiDataStore', () => {
+      return {
+        courseCache: mockCourseCacheStore,
+        programCache: mockProgramCacheStore
+      };
+    });
+    mockProgramCacheStore.set(apiDataConfig.apiData.programData);
+    mockCourseCacheStore.set(apiDataConfig.apiData.courseData);
+  });
+
   test('empty term', () => {
     render(TermContainer, {
       props: {
@@ -27,7 +49,7 @@ describe('TermContainer component tests', () => {
     render(TermContainer, {
       props: {
         flowId: '68be11b7-389b-4ebc-9b95-8997e7314497',
-        flowProgramId: ['68be11b7-389b-4ebc-9b95-8997e7314497'],
+        flowProgramId: ['4fc5d3c2-f5a7-4074-ae3d-5b3e01cb1168'],
         term: TEST_TERM_COURSES,
         termName: 'test term 2'
       }

--- a/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
@@ -7,10 +7,10 @@
   import { userFlowcharts } from '$lib/client/stores/userDataStore';
   import { selectedFlowIndex } from '$lib/client/stores/UIDataStore';
   import { COURSE_ITEM_SIZE_PX } from '$lib/client/config/uiConfig';
+  import { getCatalogFromProgramID } from '$lib/common/util/flowDataUtilCommon';
   import { searchHelpTooltipConfig } from '$lib/client/config/catalogSearchConfigClient';
   import { buildTermCourseItemsData } from '$lib/client/util/courseItemUtil';
   import { courseCache, programCache } from '$lib/client/stores/apiDataStore';
-  import { getCatalogFromProgramIDIndex } from '$lib/common/util/courseDataUtilCommon';
   import { initSearch, transformRawQuery } from '$lib/client/util/courseSearchUtil';
   import { MAX_SEARCH_RESULTS_RETURN_COUNT } from '$lib/common/config/catalogSearchConfig';
   import { activeSearchResults, searchCache } from '$lib/client/stores/catalogSearchStore';
@@ -41,9 +41,9 @@
     query = '';
   }
 
-  $: selectedCatalog = getCatalogFromProgramIDIndex(
-    searchProgramIndex,
+  $: selectedCatalog = getCatalogFromProgramID(
     selectedFlow?.programId ?? [''],
+    searchProgramIndex,
     $programCache
   );
   $: {

--- a/src/lib/server/util/courseCacheUtil.ts
+++ b/src/lib/server/util/courseCacheUtil.ts
@@ -33,7 +33,7 @@ export async function generateCourseCacheFlowcharts(
         if (c.id) {
           // select the correct catalog
           const courseCatalog = getCatalogFromProgramIDIndex(
-            c.programIdIndex ?? 0,
+            c.programIdIndex,
             flowchart.programId,
             programCache
           );
@@ -130,7 +130,7 @@ export async function generateCourseCacheFromUpdateChunks(
         // add course to cache only if noncustom
         if (course.id) {
           const courseCatalog = getCatalogFromProgramIDIndex(
-            course.programIdIndex ?? 0,
+            course.programIdIndex,
             flowchart.programId,
             programCache
           );

--- a/src/lib/server/util/courseCacheUtil.ts
+++ b/src/lib/server/util/courseCacheUtil.ts
@@ -1,7 +1,7 @@
 import { ObjectMap } from '$lib/common/util/ObjectMap';
 import { initLogger } from '$lib/common/config/loggerConfig';
 import { getCourseData } from '$lib/server/db/course';
-import { getCatalogFromProgramIDIndex } from '$lib/common/util/courseDataUtilCommon';
+import { getCatalogFromProgramID } from '$lib/common/util/flowDataUtilCommon';
 import { UserDataUpdateChunkType, UserDataUpdateChunkTERM_MODCourseDataFrom } from '$lib/types';
 import type { UserDataUpdateChunk } from '$lib/common/schema/mutateUserDataSchema';
 import type { Course, Flowchart, Term } from '$lib/common/schema/flowchartSchema';
@@ -32,9 +32,9 @@ export async function generateCourseCacheFlowcharts(
         // skip all custom courses
         if (c.id) {
           // select the correct catalog
-          const courseCatalog = getCatalogFromProgramIDIndex(
-            c.programIdIndex,
+          const courseCatalog = getCatalogFromProgramID(
             flowchart.programId,
+            c.programIdIndex,
             programCache
           );
 
@@ -129,9 +129,9 @@ export async function generateCourseCacheFromUpdateChunks(
 
         // add course to cache only if noncustom
         if (course.id) {
-          const courseCatalog = getCatalogFromProgramIDIndex(
-            course.programIdIndex,
+          const courseCatalog = getCatalogFromProgramID(
             flowchart.programId,
+            course.programIdIndex,
             programCache
           );
 

--- a/src/lib/server/util/flowDataUtil.ts
+++ b/src/lib/server/util/flowDataUtil.ts
@@ -139,7 +139,7 @@ export async function generateFlowchart(
           if (c.id) {
             allRemovedCoursesKeysSet.add(
               `${getCatalogFromProgramIDIndex(
-                c.programIdIndex ?? 0,
+                c.programIdIndex,
                 generatedFlowchart.programId,
                 programCache
               )}|${c.id}`

--- a/src/lib/server/util/flowDataUtil.ts
+++ b/src/lib/server/util/flowDataUtil.ts
@@ -1,10 +1,13 @@
 import { COLORS } from '$lib/common/config/colorConfig';
 import { v4 as uuid } from 'uuid';
 import { getTemplateFlowcharts } from '$lib/server/db/templateFlowchart';
-import { getCatalogFromProgramIDIndex } from '$lib/common/util/courseDataUtilCommon';
 import { generateCourseCacheFlowcharts } from '$lib/server/util/courseCacheUtil';
 import { computeTermUnits, computeTotalUnits } from '$lib/common/util/unitCounterUtilCommon';
-import { generateFlowHash, mergeFlowchartsCourseData } from '$lib/common/util/flowDataUtilCommon';
+import {
+  generateFlowHash,
+  getCatalogFromProgramID,
+  mergeFlowchartsCourseData
+} from '$lib/common/util/flowDataUtilCommon';
 import {
   FLOW_NOTES_MAX_LENGTH,
   FLOW_DEFAULT_TERM_DATA,
@@ -138,9 +141,9 @@ export async function generateFlowchart(
           // they dont need to be removed from courseCache
           if (c.id) {
             allRemovedCoursesKeysSet.add(
-              `${getCatalogFromProgramIDIndex(
-                c.programIdIndex,
+              `${getCatalogFromProgramID(
                 generatedFlowchart.programId,
+                c.programIdIndex,
                 programCache
               )}|${c.id}`
             );

--- a/src/lib/server/util/generatePDF.ts
+++ b/src/lib/server/util/generatePDF.ts
@@ -58,6 +58,11 @@ export function extractPDFDataFromFlowchart(
         courseCache,
         programCache
       );
+      if (course.id && !courseMetadata) {
+        throw new Error(
+          `extractPDFDataFromFlowchart: unable to find course metadata for course ${course.id}`
+        );
+      }
       termData.tData.push(computeCourseDisplayValues(course, courseMetadata, false));
     });
 

--- a/tests/util/testFlowcharts.ts
+++ b/tests/util/testFlowcharts.ts
@@ -10,7 +10,7 @@ export const TEST_FLOWCHART_SINGLE_PROGRAM_1: Flowchart = {
   name: '',
   notes: '',
   ownerId: '',
-  programId: ['68be11b7-389b-4ebc-9b95-8997e7314497'],
+  programId: ['fd2f33be-3103-4b3d-a17b-94ced0d7998f'],
   startYear: '',
   unitTotal: '500', // just a test value
   version: CURRENT_FLOW_DATA_VERSION,


### PR DESCRIPTION
This PR makes minor improvement to how `getCatalogFromProgramID()` (formerly `getCatalogFromProgramIDIndex()`) is consumed in the application.

Additionally, some extra error checking logic was introduced to consumers of `getCourseFromCourseCache()`, exposing a couple of bugs in the associated tests.

Tests were fixed to accommodate these changes.