### PR TITLE
feat: update `majorName` cache

### DIFF
--- a/src/lib/client/stores/apiDataStore.ts
+++ b/src/lib/client/stores/apiDataStore.ts
@@ -10,5 +10,5 @@ export const availableFlowchartCatalogs = writeOnceStore<string[]>([]);
 // API data caches
 export const programCache = writable<ProgramCache>(new Map());
 export const courseCache = writable<CourseCache>(new ObjectMap());
-export const majorNameCache = writable<MajorNameCache[]>([]);
+export const majorNameCache = writable<MajorNameCache>(new Map());
 export const catalogMajorNameCache = writable<Set<string>>(new Set<string>());

--- a/src/lib/components/common/FlowPropertiesSelector/ProgramSelector.svelte
+++ b/src/lib/components/common/FlowPropertiesSelector/ProgramSelector.svelte
@@ -81,29 +81,29 @@
 
   // load major and concentration options for UI
   async function loadMajorOptions(progCatalogYear: string) {
-    let idx = $majorNameCache.findIndex((cacheEntry) => cacheEntry.catalog === progCatalogYear);
+    let majorNameCacheEntry = $majorNameCache.get(progCatalogYear);
 
     // does not exist, fetch entries
-    if (idx === -1) {
+    if (!majorNameCacheEntry) {
       dispatch('fetchingDataUpdate', true);
       const res = await fetch(`/api/data/queryAvailableMajors?catalog=${progCatalogYear}`);
       const resJson = (await res.json()) as {
         message: string;
         results: string[];
       };
-      $majorNameCache = [
-        ...$majorNameCache,
-        {
-          catalog: progCatalogYear,
-          majorNames: resJson.results.sort()
-        }
-      ];
-      idx = $majorNameCache.length - 1;
+      majorNameCache.update((cache) => {
+        cache.set(progCatalogYear, resJson.results.sort());
+        return cache;
+      });
+      majorNameCacheEntry = $majorNameCache.get(progCatalogYear);
+      if (!majorNameCacheEntry) {
+        throw new Error('loadMajorOptions: majorNameCacheEntry not found after fetch');
+      }
       dispatch('fetchingDataUpdate', false);
     }
 
     // select
-    majorOptions = $majorNameCache[idx].majorNames;
+    majorOptions = majorNameCacheEntry;
   }
   async function loadConcentrationOptions(progCatalogYear: string, majorName: string) {
     // fetch programs for this program if we don't have them

--- a/src/lib/types/apiDataTypes.ts
+++ b/src/lib/types/apiDataTypes.ts
@@ -15,15 +15,11 @@ export interface CourseCacheKey {
   catalog: string;
   id: string;
 }
-
 export type CourseCache = ObjectMap<CourseCacheKey, APICourseFull>;
 
 export type ProgramCache = Map<string, Program>;
 
-export interface MajorNameCache {
-  catalog: string;
-  majorNames: string[];
-}
+export type MajorNameCache = Map<string, string[]>;
 
 export interface APIData {
   // available flowchart data

--- a/tests/util/storeMocks.ts
+++ b/tests/util/storeMocks.ts
@@ -13,7 +13,7 @@ const mockAvailableFlowchartStartYearsWritable = writable<string[]>([]);
 const mockAvailableFlowchartCatalogsWritable = writable<string[]>([]);
 const mockProgramCacheWritable = writable<ProgramCache>(new Map());
 const mockCourseCacheWritable = writable<CourseCache>(new ObjectMap());
-const mockMajorNameCacheWritable = writable<MajorNameCache[]>([]);
+const mockMajorNameCacheWritable = writable<MajorNameCache>(new Map());
 const mockCatalogMajorNameCacheWritable = writable<Set<string>>(new Set<string>());
 const mockModalOpenWritable = writable<boolean>(false);
 const mockSelectedFlowIndexWritable = writable<number>(-1);
@@ -49,20 +49,19 @@ export function initMockedAPIDataStores() {
   const mockCatalogMajorNameCacheValue = new Set(
     apiDataProgramDataArr.map((entry) => `${entry.catalog}|${entry.majorName}`)
   );
-  const mockMajorNameCacheValue = apiData.catalogs.map((catalog) => {
-    const majorNames = [
-      ...new Set(
-        apiDataProgramDataArr
-          .filter((entry) => entry.catalog === catalog)
-          .map((entry) => entry.majorName)
-          .sort()
-      )
-    ];
-    return {
-      catalog,
-      majorNames
-    };
-  });
+  const mockMajorNameCacheValue = new Map(
+    apiData.catalogs.map((catalog) => {
+      const majorNames = [
+        ...new Set(
+          apiDataProgramDataArr
+            .filter((entry) => entry.catalog === catalog)
+            .map((entry) => entry.majorName)
+            .sort()
+        )
+      ];
+      return [catalog, majorNames];
+    })
+  );
 
   mockAvailableFlowchartStartYearsStore.set(apiData.startYears);
   mockAvailableFlowchartCatalogsStore.set(apiData.catalogs);


### PR DESCRIPTION
part of #11

This PR updates the `MajorNameCache` type from `{ catalog: string; majorNames: string[]}[]` to `Map<string, string[]>`.

Tests were updated to accommodate these changes.