### PR TITLE
feat: improve `ProgramSelector` caches

### DIFF
--- a/src/lib/client/stores/apiDataStore.ts
+++ b/src/lib/client/stores/apiDataStore.ts
@@ -1,7 +1,7 @@
 import { writable } from 'svelte/store';
 import { ObjectMap } from '$lib/common/util/ObjectMap';
 import { writeOnceStore } from '$lib/client/stores/util';
-import type { CourseCache, MajorNameCache, ProgramCache } from '$lib/types';
+import type { ConcOptionsCache, CourseCache, MajorNameCache, ProgramCache } from '$lib/types';
 
 // API data for flowcharts
 export const availableFlowchartStartYears = writeOnceStore<string[]>([]);
@@ -11,4 +11,4 @@ export const availableFlowchartCatalogs = writeOnceStore<string[]>([]);
 export const programCache = writable<ProgramCache>(new Map());
 export const courseCache = writable<CourseCache>(new ObjectMap());
 export const majorNameCache = writable<MajorNameCache>(new Map());
-export const catalogMajorNameCache = writable<Set<string>>(new Set<string>());
+export const concOptionsCache = writable<ConcOptionsCache>(new ObjectMap());

--- a/src/lib/client/stores/apiDataStore.ts
+++ b/src/lib/client/stores/apiDataStore.ts
@@ -1,7 +1,7 @@
 import { writable } from 'svelte/store';
 import { ObjectMap } from '$lib/common/util/ObjectMap';
 import { writeOnceStore } from '$lib/client/stores/util';
-import type { ConcOptionsCache, CourseCache, MajorNameCache, ProgramCache } from '$lib/types';
+import type { ConcOptionsCache, CourseCache, MajorOptionsCache, ProgramCache } from '$lib/types';
 
 // API data for flowcharts
 export const availableFlowchartStartYears = writeOnceStore<string[]>([]);
@@ -10,5 +10,5 @@ export const availableFlowchartCatalogs = writeOnceStore<string[]>([]);
 // API data caches
 export const programCache = writable<ProgramCache>(new Map());
 export const courseCache = writable<CourseCache>(new ObjectMap());
-export const majorNameCache = writable<MajorNameCache>(new Map());
+export const majorOptionsCache = writable<MajorOptionsCache>(new Map());
 export const concOptionsCache = writable<ConcOptionsCache>(new ObjectMap());

--- a/src/lib/components/Flows/modals/NewFlowModal.test.ts
+++ b/src/lib/components/Flows/modals/NewFlowModal.test.ts
@@ -8,7 +8,7 @@ import {
   mockProgramCacheStore,
   mockMajorNameCacheStore,
   initMockedAPIDataStores,
-  mockCatalogMajorNameCacheStore,
+  mockConcOptionsCacheStore,
   mockAvailableFlowchartCatalogsStore,
   mockAvailableFlowchartStartYearsStore
 } from '../../../../../tests/util/storeMocks';
@@ -34,7 +34,7 @@ describe('NewFlowModal component tests', () => {
         courseCache: mockCourseCacheStore,
         programCache: mockProgramCacheStore,
         majorNameCache: mockMajorNameCacheStore,
-        catalogMajorNameCache: mockCatalogMajorNameCacheStore,
+        concOptionsCache: mockConcOptionsCacheStore,
         availableFlowchartCatalogs: mockAvailableFlowchartCatalogsStore,
         availableFlowchartStartYears: mockAvailableFlowchartStartYearsStore
       };

--- a/src/lib/components/Flows/modals/NewFlowModal.test.ts
+++ b/src/lib/components/Flows/modals/NewFlowModal.test.ts
@@ -6,9 +6,9 @@ import {
   mockModalOpenStore,
   mockCourseCacheStore,
   mockProgramCacheStore,
-  mockMajorNameCacheStore,
   initMockedAPIDataStores,
   mockConcOptionsCacheStore,
+  mockMajorOptionsCacheStore,
   mockAvailableFlowchartCatalogsStore,
   mockAvailableFlowchartStartYearsStore
 } from '../../../../../tests/util/storeMocks';
@@ -33,8 +33,8 @@ describe('NewFlowModal component tests', () => {
       return {
         courseCache: mockCourseCacheStore,
         programCache: mockProgramCacheStore,
-        majorNameCache: mockMajorNameCacheStore,
         concOptionsCache: mockConcOptionsCacheStore,
+        majorOptionsCache: mockMajorOptionsCacheStore,
         availableFlowchartCatalogs: mockAvailableFlowchartCatalogsStore,
         availableFlowchartStartYears: mockAvailableFlowchartStartYearsStore
       };

--- a/src/lib/components/common/FlowPropertiesSelector/Component.test.ts
+++ b/src/lib/components/common/FlowPropertiesSelector/Component.test.ts
@@ -6,7 +6,7 @@ import {
   mockProgramCacheStore,
   mockMajorNameCacheStore,
   initMockedAPIDataStores,
-  mockCatalogMajorNameCacheStore,
+  mockConcOptionsCacheStore,
   mockAvailableFlowchartCatalogsStore,
   mockAvailableFlowchartStartYearsStore
 } from '../../../../../tests/util/storeMocks';
@@ -102,11 +102,11 @@ describe('FlowPropertiesSelector/Component initial mount tests', () => {
   beforeAll(() => {
     vi.mock('$lib/client/stores/apiDataStore', () => {
       return {
-        availableFlowchartStartYears: mockAvailableFlowchartStartYearsStore,
-        availableFlowchartCatalogs: mockAvailableFlowchartCatalogsStore,
         programCache: mockProgramCacheStore,
-        catalogMajorNameCache: mockCatalogMajorNameCacheStore,
-        majorNameCache: mockMajorNameCacheStore
+        majorNameCache: mockMajorNameCacheStore,
+        concOptionsCache: mockConcOptionsCacheStore,
+        availableFlowchartCatalogs: mockAvailableFlowchartCatalogsStore,
+        availableFlowchartStartYears: mockAvailableFlowchartStartYearsStore
       };
     });
   });

--- a/src/lib/components/common/FlowPropertiesSelector/Component.test.ts
+++ b/src/lib/components/common/FlowPropertiesSelector/Component.test.ts
@@ -4,9 +4,9 @@ import { vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import {
   mockProgramCacheStore,
-  mockMajorNameCacheStore,
   initMockedAPIDataStores,
   mockConcOptionsCacheStore,
+  mockMajorOptionsCacheStore,
   mockAvailableFlowchartCatalogsStore,
   mockAvailableFlowchartStartYearsStore
 } from '../../../../../tests/util/storeMocks';
@@ -103,8 +103,8 @@ describe('FlowPropertiesSelector/Component initial mount tests', () => {
     vi.mock('$lib/client/stores/apiDataStore', () => {
       return {
         programCache: mockProgramCacheStore,
-        majorNameCache: mockMajorNameCacheStore,
         concOptionsCache: mockConcOptionsCacheStore,
+        majorOptionsCache: mockMajorOptionsCacheStore,
         availableFlowchartCatalogs: mockAvailableFlowchartCatalogsStore,
         availableFlowchartStartYears: mockAvailableFlowchartStartYearsStore
       };

--- a/src/lib/components/common/FlowPropertiesSelector/ProgramSelector.svelte
+++ b/src/lib/components/common/FlowPropertiesSelector/ProgramSelector.svelte
@@ -161,10 +161,10 @@
     });
     if (!concOptionsCacheEntry) {
       throw new Error(
-        `loadConcentrationOptions: concOptionsCacheEntry empty for entry ${{
+        `loadConcentrationOptions: concOptionsCacheEntry empty for entry ${JSON.stringify({
           catalog: progCatalogYear,
           majorName
-        }}`
+        })}`
       );
     }
     concOptions = concOptionsCacheEntry;

--- a/src/lib/components/common/FlowPropertiesSelector/ProgramSelector.test.ts
+++ b/src/lib/components/common/FlowPropertiesSelector/ProgramSelector.test.ts
@@ -6,7 +6,7 @@ import {
   mockProgramCacheStore,
   initMockedAPIDataStores,
   mockMajorNameCacheStore,
-  mockCatalogMajorNameCacheStore,
+  mockConcOptionsCacheStore,
   mockAvailableFlowchartCatalogsStore
 } from '../../../../../tests/util/storeMocks';
 import type { Program } from '@prisma/client';
@@ -28,10 +28,10 @@ describe('FlowPropertiesSelector/ProgramSelector initial mount tests', () => {
   beforeAll(() => {
     vi.mock('$lib/client/stores/apiDataStore', () => {
       return {
-        availableFlowchartCatalogs: mockAvailableFlowchartCatalogsStore,
         programCache: mockProgramCacheStore,
-        catalogMajorNameCache: mockCatalogMajorNameCacheStore,
-        majorNameCache: mockMajorNameCacheStore
+        majorNameCache: mockMajorNameCacheStore,
+        concOptionsCache: mockConcOptionsCacheStore,
+        availableFlowchartCatalogs: mockAvailableFlowchartCatalogsStore
       };
     });
     mockAvailableFlowchartCatalogsStore.set(apiDataConfig.apiData.catalogs);

--- a/src/lib/components/common/FlowPropertiesSelector/ProgramSelector.test.ts
+++ b/src/lib/components/common/FlowPropertiesSelector/ProgramSelector.test.ts
@@ -5,8 +5,8 @@ import { act, render, screen, getAllByRole, findByRole } from '@testing-library/
 import {
   mockProgramCacheStore,
   initMockedAPIDataStores,
-  mockMajorNameCacheStore,
   mockConcOptionsCacheStore,
+  mockMajorOptionsCacheStore,
   mockAvailableFlowchartCatalogsStore
 } from '../../../../../tests/util/storeMocks';
 import type { Program } from '@prisma/client';
@@ -29,8 +29,8 @@ describe('FlowPropertiesSelector/ProgramSelector initial mount tests', () => {
     vi.mock('$lib/client/stores/apiDataStore', () => {
       return {
         programCache: mockProgramCacheStore,
-        majorNameCache: mockMajorNameCacheStore,
         concOptionsCache: mockConcOptionsCacheStore,
+        majorOptionsCache: mockMajorOptionsCacheStore,
         availableFlowchartCatalogs: mockAvailableFlowchartCatalogsStore
       };
     });

--- a/src/lib/types/apiDataTypes.ts
+++ b/src/lib/types/apiDataTypes.ts
@@ -21,6 +21,16 @@ export type ProgramCache = Map<string, Program>;
 
 export type MajorNameCache = Map<string, string[]>;
 
+export interface ConcOptionsCacheKey {
+  catalog: string;
+  majorName: string;
+}
+export interface ConcOptionsCacheValue {
+  name: string;
+  id: string;
+}
+export type ConcOptionsCache = ObjectMap<ConcOptionsCacheKey, ConcOptionsCacheValue[]>;
+
 export interface APIData {
   // available flowchart data
   catalogs: string[];

--- a/src/lib/types/apiDataTypes.ts
+++ b/src/lib/types/apiDataTypes.ts
@@ -19,7 +19,7 @@ export type CourseCache = ObjectMap<CourseCacheKey, APICourseFull>;
 
 export type ProgramCache = Map<string, Program>;
 
-export type MajorNameCache = Map<string, string[]>;
+export type MajorOptionsCache = Map<string, string[]>;
 
 export interface ConcOptionsCacheKey {
   catalog: string;

--- a/tests/util/storeMocks.ts
+++ b/tests/util/storeMocks.ts
@@ -6,14 +6,14 @@ import { apiData } from '$lib/server/config/apiDataConfig';
 import { writable } from 'svelte/store';
 import { ObjectMap } from '$lib/common/util/ObjectMap';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
-import type { MajorNameCache, CourseCache, ProgramCache, ConcOptionsCache } from '$lib/types';
+import type { MajorOptionsCache, CourseCache, ProgramCache, ConcOptionsCache } from '$lib/types';
 
 // set stores
 const mockAvailableFlowchartStartYearsWritable = writable<string[]>([]);
 const mockAvailableFlowchartCatalogsWritable = writable<string[]>([]);
 const mockProgramCacheWritable = writable<ProgramCache>(new Map());
 const mockCourseCacheWritable = writable<CourseCache>(new ObjectMap());
-const mockMajorNameCacheWritable = writable<MajorNameCache>(new Map());
+const mockMajorOptionsCacheWritable = writable<MajorOptionsCache>(new Map());
 const mockConcOptionsCacheWritable = writable<ConcOptionsCache>(new ObjectMap());
 const mockModalOpenWritable = writable<boolean>(false);
 const mockSelectedFlowIndexWritable = writable<number>(-1);
@@ -28,7 +28,7 @@ export const mockAvailableFlowchartCatalogsStore = mockAvailableFlowchartCatalog
 // caches
 export const mockProgramCacheStore = mockProgramCacheWritable;
 export const mockCourseCacheStore = mockCourseCacheWritable;
-export const mockMajorNameCacheStore = mockMajorNameCacheWritable;
+export const mockMajorOptionsCacheStore = mockMajorOptionsCacheWritable;
 export const mockConcOptionsCacheStore = mockConcOptionsCacheWritable;
 
 // general-purpose mock modal store since we will only be
@@ -74,7 +74,7 @@ export function initMockedAPIDataStores() {
     }
   });
 
-  const mockMajorNameCacheValue = new Map(
+  const mockMajorOptionsCacheValue = new Map(
     apiData.catalogs.map((catalog) => {
       const majorNames = [
         ...new Set(
@@ -91,6 +91,6 @@ export function initMockedAPIDataStores() {
   mockAvailableFlowchartStartYearsStore.set(apiData.startYears);
   mockAvailableFlowchartCatalogsStore.set(apiData.catalogs);
   mockProgramCacheStore.set(apiData.programData);
-  mockMajorNameCacheStore.set(mockMajorNameCacheValue);
+  mockMajorOptionsCacheStore.set(mockMajorOptionsCacheValue);
   mockConcOptionsCacheStore.set(mockConcOptionsCacheValue);
 }

--- a/tests/util/storeMocks.ts
+++ b/tests/util/storeMocks.ts
@@ -6,7 +6,7 @@ import { apiData } from '$lib/server/config/apiDataConfig';
 import { writable } from 'svelte/store';
 import { ObjectMap } from '$lib/common/util/ObjectMap';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
-import type { MajorNameCache, CourseCache, ProgramCache } from '$lib/types';
+import type { MajorNameCache, CourseCache, ProgramCache, ConcOptionsCache } from '$lib/types';
 
 // set stores
 const mockAvailableFlowchartStartYearsWritable = writable<string[]>([]);
@@ -14,7 +14,7 @@ const mockAvailableFlowchartCatalogsWritable = writable<string[]>([]);
 const mockProgramCacheWritable = writable<ProgramCache>(new Map());
 const mockCourseCacheWritable = writable<CourseCache>(new ObjectMap());
 const mockMajorNameCacheWritable = writable<MajorNameCache>(new Map());
-const mockCatalogMajorNameCacheWritable = writable<Set<string>>(new Set<string>());
+const mockConcOptionsCacheWritable = writable<ConcOptionsCache>(new ObjectMap());
 const mockModalOpenWritable = writable<boolean>(false);
 const mockSelectedFlowIndexWritable = writable<number>(-1);
 const mockUserFlowchartsWritable = writable<Flowchart[]>([]);
@@ -29,7 +29,7 @@ export const mockAvailableFlowchartCatalogsStore = mockAvailableFlowchartCatalog
 export const mockProgramCacheStore = mockProgramCacheWritable;
 export const mockCourseCacheStore = mockCourseCacheWritable;
 export const mockMajorNameCacheStore = mockMajorNameCacheWritable;
-export const mockCatalogMajorNameCacheStore = mockCatalogMajorNameCacheWritable;
+export const mockConcOptionsCacheStore = mockConcOptionsCacheWritable;
 
 // general-purpose mock modal store since we will only be
 // using this mock for one store at a time
@@ -46,9 +46,34 @@ export function initMockedAPIDataStores() {
 
   const apiDataProgramDataArr = Array.from(apiData.programData.values());
 
-  const mockCatalogMajorNameCacheValue = new Set(
-    apiDataProgramDataArr.map((entry) => `${entry.catalog}|${entry.majorName}`)
-  );
+  const mockConcOptionsCacheValue: ConcOptionsCache = new ObjectMap();
+  apiDataProgramDataArr.forEach((entry) => {
+    const cacheEntry =
+      mockConcOptionsCacheValue.get({
+        catalog: entry.catalog,
+        majorName: entry.majorName
+      }) ?? [];
+    if (!cacheEntry.find((e) => e.id === entry.id)) {
+      if (!entry.concName) {
+        throw new Error(`initMockedAPIDataStores: concName null for program ${entry.id}`);
+      }
+
+      cacheEntry.push({
+        name: entry.concName,
+        id: entry.id
+      });
+      cacheEntry.sort((a, b) => a.name.localeCompare(b.name));
+
+      mockConcOptionsCacheValue.set(
+        {
+          catalog: entry.catalog,
+          majorName: entry.majorName
+        },
+        cacheEntry
+      );
+    }
+  });
+
   const mockMajorNameCacheValue = new Map(
     apiData.catalogs.map((catalog) => {
       const majorNames = [
@@ -67,5 +92,5 @@ export function initMockedAPIDataStores() {
   mockAvailableFlowchartCatalogsStore.set(apiData.catalogs);
   mockProgramCacheStore.set(apiData.programData);
   mockMajorNameCacheStore.set(mockMajorNameCacheValue);
-  mockCatalogMajorNameCacheStore.set(mockCatalogMajorNameCacheValue);
+  mockConcOptionsCacheStore.set(mockConcOptionsCacheValue);
 }


### PR DESCRIPTION
part of #11

This PR improves the two caches that are used by the `ProgramSelector` component: the `majorOptionsCache` and the `concOptionsCache`. The `concOptionsCache` was updated to use the type `ObjectMap<ConcOptionsCacheKey, ConcOptionsCacheValue>`, and both caches have slightly improved logic in the `ProgramSelector`.

Tests were fixed to accommodate these changes.