### PR TITLE
fix: update PDF template to not display course units when they are 0

### DIFF
--- a/api/data/flows/exports/flowexport.ejs
+++ b/api/data/flows/exports/flowexport.ejs
@@ -87,8 +87,7 @@
                   text-align: center;
                 "
               >
-                <%= c.units === "1" ? "1 unit" : (c.units === undefined ? "" : c.units + " units")
-                %>
+                <%= c.units !== '0' ? `${c.units} unit${c.units !== '1' ? 's' : ''}` : '' %>
               </h6>
             </div>
             <% }); %>


### PR DESCRIPTION
This PR is a small change that updates the flowchart PDF template to not display a course's units when they are `0`.

Tests will be added in a later ticket. Functionality was verified manually.