### PR TITLE
feat: improve scrollbars on Windows/Linux platforms

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -102,3 +102,24 @@ button.btn-accent:focus-visible {
   padding-right: 1rem; /* 16 px */
   user-select: none;
 }
+
+/* firefox scrollbar */
+.scrollbar-thin * {
+  scrollbar-width: thin;
+  scrollbar-color: #cdcdcd transparent;
+}
+
+/* blink and webkit scrollbar */
+.scrollbar-thin *::-webkit-scrollbar {
+  width: 8px; /* vertical scrollbar */
+  height: 8px; /* horizontal scrollbar */
+}
+.scrollbar-thin *::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollbar-thin *::-webkit-scrollbar-thumb {
+  background-color: #cdcdcd;
+}
+.scrollbar-thin *::-webkit-scrollbar-thumb:hover {
+  background-color: #a0a0a0;
+}

--- a/src/lib/client/config/uiConfig.ts
+++ b/src/lib/client/config/uiConfig.ts
@@ -10,6 +10,6 @@ export const MODAL_CLOSE_TIME_MS = 100;
 export const FLOW_EDITOR_HEADER_PADDING_PX = 192;
 
 export const TERM_CONTAINER_WIDTH_PX = 130;
-export const COURSE_ITEM_SIZE_PX = 116;
+export const COURSE_ITEM_SIZE_PX = 112;
 
 export const COLOR_PICKER_UI_DEFAULT_COLOR = '#1B733C';

--- a/src/lib/components/Flows/FlowEditor/CourseItem.svelte
+++ b/src/lib/components/Flows/FlowEditor/CourseItem.svelte
@@ -29,7 +29,7 @@
 -->
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
-  class="courseItem select-none card shadow inline-block rounded-none p-1 w-full h-full"
+  class="courseItem select-none card shadow inline-block rounded-none p-[2px] w-full h-full"
   class:selected={item.metadata.selected}
   style="background-color: {color}"
   on:click={onCourseItemClick}

--- a/src/lib/components/Flows/FlowEditor/FlowEditor.svelte
+++ b/src/lib/components/Flows/FlowEditor/FlowEditor.svelte
@@ -83,7 +83,7 @@
   <!-- bind here bc if we bind width in child element below centering of term containers breaks -->
   <div class="flowEditorTermsContainer" bind:clientWidth={termsContainerClientWidth}>
     <div
-      class="h-full flex border-2 overflow-x-scroll border-slate-400"
+      class="h-full flex border-2 overflow-x-auto border-slate-400"
       bind:this={termsContainer}
       on:scroll={scrollEventHandler}
     >

--- a/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/AddCoursesTab/Component.svelte
@@ -123,7 +123,6 @@
             >
           </div>
         {:else}
-          <!-- TODO: the text in the slot should always stay at the bottom of the results section -->
           <MutableForEachContainer
             {items}
             component={CourseItem}
@@ -133,7 +132,7 @@
             itemStyle="width: {COURSE_ITEM_SIZE_PX}px; height: {COURSE_ITEM_SIZE_PX}px; margin: 0.5rem auto;"
             containerStyle="display: grid; grid-template-columns: repeat(2, 1fr); text-align: center;"
           >
-            <div class="text-center">
+            <div class="text-center px-1">
               {#if results.searchLimitExceeded}
                 <small class="text-gray-500"
                   >Search results were capped at {MAX_SEARCH_RESULTS_RETURN_COUNT} courses.</small

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -31,7 +31,7 @@
   ></script>
 </svelte:head>
 
-<div class="min-h-screen flex flex-col">
+<div class="min-h-screen flex flex-col scrollbar-thin">
   <Header />
   <div class="flex-1">
     <slot />


### PR DESCRIPTION
closes #87.

This PR improves the scrollbar experience by replacing the standard scrollbars with thin ones. Additionally, the `CourseItem` blocks are shrunk down by a few pixels to address scrollbars pushing the content around. See below:

![image](https://github.com/polyflowbuilder/polyflowbuilder/assets/9858271/a8452644-5083-40c3-8554-5a5f0ee88f37)

Heavy investigation was done to see if the macOS scrollbar experience could be emulated in Windows/Linux platforms, but this involves using 3rd party JS libraries (e.g. OverlayScrollbars, Simplebar, etc.) that pollute the DOM and generally add to the bundle size of the application. Therefore, I believe this is a good middle ground and improves the scrollbar experience for everyone.

All existing tests are passing with these changes.