### PR TITLE
feat: add ability to show/hide the flowchart info panel

### DIFF
--- a/src/lib/client/config/uiConfig.ts
+++ b/src/lib/client/config/uiConfig.ts
@@ -7,7 +7,7 @@ export const PANEL_SIZE_CLOSED = 0;
 export const MODAL_CLOSE_TIME_MS = 100;
 
 // roughly the pixel width of the buttons + some padding on the right
-export const FLOW_EDITOR_HEADER_PADDING_PX = 192;
+export const FLOW_EDITOR_HEADER_PADDING_PX = 256;
 
 export const TERM_CONTAINER_WIDTH_PX = 130;
 export const COURSE_ITEM_SIZE_PX = 112;

--- a/src/lib/client/stores/UIDataStore.ts
+++ b/src/lib/client/stores/UIDataStore.ts
@@ -41,8 +41,10 @@ export const flowListUIData = derived([userFlowcharts, programCache], ([userFlow
 
 export const selectedFlowIndex = writable<number>(-1);
 
-export const viewingCreditBin = writable(false);
-
 export const selectedCourses = writable<Set<string>>(new Set());
 
 export const selectedColor = writable<string>(COLOR_PICKER_UI_DEFAULT_COLOR);
+
+export const viewingCreditBin = writable(false);
+
+export const viewingFlowInfoPanel = writable(true);

--- a/src/lib/components/Flows/FlowEditor/FlowEditorHeader.svelte
+++ b/src/lib/components/Flows/FlowEditor/FlowEditorHeader.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import Fa from 'svelte-fa';
+  import { viewingFlowInfoPanel } from '$lib/client/stores/UIDataStore';
   import { createEventDispatcher } from 'svelte';
-  import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
+  import { faArrowLeft, faArrowRight, faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
   import {
-    FLOW_EDITOR_HEADER_PADDING_PX,
-    TERM_CONTAINER_WIDTH_PX
+    TERM_CONTAINER_WIDTH_PX,
+    FLOW_EDITOR_HEADER_PADDING_PX
   } from '$lib/client/config/uiConfig';
 
   export let name: string;
@@ -32,6 +33,13 @@
     <div class="absolute left-2 bottom-[0.125rem] font-bold">
       <button
         class="btn btn-sm btn-square btn-ghost"
+        aria-label="show/hide flow info panel"
+        on:click={() => ($viewingFlowInfoPanel = !$viewingFlowInfoPanel)}
+      >
+        <Fa icon={$viewingFlowInfoPanel ? faEye : faEyeSlash} />
+      </button>
+      <button
+        class="btn btn-sm btn-square btn-ghost"
         aria-label="flow editor left scroll"
         disabled={!enableLeftScrollArrow}
         on:click={() => dispatch('leftScrollArrowClick')}
@@ -57,7 +65,6 @@
       </h2>
     </div>
   </div>
-  <div class="divider my-0" />
 </div>
 
 <style lang="postcss">

--- a/src/lib/components/Flows/FlowInfoPanel/FlowInfoPanel.svelte
+++ b/src/lib/components/Flows/FlowInfoPanel/FlowInfoPanel.svelte
@@ -2,16 +2,16 @@
 <script lang="ts">
   import { tweened } from 'svelte/motion';
   import { cubicOut } from 'svelte/easing';
+  import { viewingFlowInfoPanel } from '$lib/client/stores/UIDataStore';
   import { AddCoursesTab, ManageFlowsTab } from '$lib/components/Flows/FlowInfoPanel';
   import { PANEL_SIZE_CLOSED, PANEL_SIZE_OPEN } from '$lib/client/config/uiConfig';
 
   // collapsible side panel logic
-  let visible = true;
   let size = tweened(PANEL_SIZE_OPEN, {
     duration: 400,
     easing: cubicOut
   });
-  $: if (visible) {
+  $: if ($viewingFlowInfoPanel) {
     void size.set(PANEL_SIZE_OPEN);
   } else {
     void size.set(PANEL_SIZE_CLOSED);
@@ -20,12 +20,10 @@
   let activeTab: 'manageFlows' | 'addCourses' = 'manageFlows';
 </script>
 
-<!-- TODO: figure out UI/UX for collapsible side panel -->
 <!-- TODO: auto-collapse when screen size too small -->
 <!-- TODO: allow overlay or permanent set -->
-<!-- <input type="checkbox" class="absolute right-0 top-0 z-20" bind:checked={visible} /> -->
 <div class="flowInfoPanel card {!$size ? 'opacity-0' : ''}" style="--boxSize: {$size}px;">
-  {#if visible && $size > PANEL_SIZE_OPEN * 0.9}
+  {#if $viewingFlowInfoPanel && $size > PANEL_SIZE_OPEN * 0.95}
     <div class="tabs justify-center mt-2">
       <a
         href={'#'}

--- a/tests/page/flows/flowViewerTests.test.ts
+++ b/tests/page/flows/flowViewerTests.test.ts
@@ -710,4 +710,90 @@ test.describe('flowchart viewer tests', () => {
       })
     ).not.toBeVisible();
   });
+
+  test('selected flowchart loads correctly into editor (some quarters, flow info panel visibility toggle)', async ({
+    page
+  }) => {
+    await performLoginFrontend(page, userEmail, 'test');
+    await expect(page).toHaveURL(/.*flows/);
+    expect((await page.textContent('h2'))?.trim()).toBe('Flows');
+    expect((await page.context().cookies())[0].name).toBe('sId');
+
+    // make sure test flows exist
+    await expect(page.locator(FLOW_LIST_ITEM_SELECTOR)).toHaveText([
+      'test flow 0',
+      'test flow 1',
+      'test flow 2',
+      'test flow 3'
+    ]);
+
+    // verify other parts of flow info panel are visible
+    await expect(page.getByRole('button', { name: 'New Flow' })).toBeVisible();
+    await expect(
+      page.getByRole('link', {
+        name: 'Manage Flows'
+      })
+    ).toBeInViewport();
+    await expect(
+      page.getByRole('link', {
+        name: 'Manage Flows'
+      })
+    ).toBeInViewport();
+
+    // verify correct state when no flowchart selected
+    await expect(
+      page.getByText('No flow selected. Please select or create a flow.')
+    ).toBeInViewport();
+
+    // pick one
+    await page.locator(FLOW_LIST_ITEM_SELECTOR).nth(2).click();
+
+    // verify that the editor loaded the selected flowchart properly
+
+    // header
+    await expect(
+      page.getByRole('heading', {
+        name: 'test flow 2'
+      })
+    ).toBeInViewport();
+
+    // verify toggle button is in the correct state
+    await expect(page.getByLabel('show/hide flow info panel')).toBeInViewport();
+    await expect(page.getByLabel('show/hide flow info panel')).toBeEnabled();
+
+    // now hide flow info panel and expect it to be gone
+    await page.getByLabel('show/hide flow info panel').click();
+    await expect(page.locator(FLOW_LIST_ITEM_SELECTOR)).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'New Flow' })).not.toBeVisible();
+    await expect(
+      page.getByRole('link', {
+        name: 'Manage Flows'
+      })
+    ).not.toBeInViewport();
+    await expect(
+      page.getByRole('link', {
+        name: 'Manage Flows'
+      })
+    ).not.toBeInViewport();
+
+    // now show and expect it to be back
+    await page.getByLabel('show/hide flow info panel').click();
+    await expect(page.locator(FLOW_LIST_ITEM_SELECTOR)).toHaveText([
+      'test flow 0',
+      'test flow 1',
+      'test flow 2',
+      'test flow 3'
+    ]);
+    await expect(page.getByRole('button', { name: 'New Flow' })).toBeVisible();
+    await expect(
+      page.getByRole('link', {
+        name: 'Manage Flows'
+      })
+    ).toBeInViewport();
+    await expect(
+      page.getByRole('link', {
+        name: 'Manage Flows'
+      })
+    ).toBeInViewport();
+  });
 });


### PR DESCRIPTION
closes #32.

This PR adds the ability for users to toggle the visibility of the flowchart info panel, by clicking on the "eye" button next to the flowchart viewer scroll buttons:

![image](https://github.com/polyflowbuilder/polyflowbuilder/assets/9858271/66484c7e-1630-447b-a097-8242bfabad2f)

The button icon will display the current view status of the flowchart info panel: the "eye" icon for visible, and an eye icon with a slash through it for not visible. See below for how it looks when the flowchart info panel is hidden:

![image](https://github.com/polyflowbuilder/polyflowbuilder/assets/9858271/c2f71f26-ef34-40a1-a028-1d1fe7092f0b)

Tests were added to accommodate this functionality.
