### PR TITLE
feat: set default tooltip options

### DIFF
--- a/src/lib/client/config/catalogSearchConfigClient.ts
+++ b/src/lib/client/config/catalogSearchConfigClient.ts
@@ -13,8 +13,10 @@ export const programSelectorTooltipConfig: Partial<Props> = {
   theme: 'light-border',
   allowHTML: true,
   content:
-    'Which program to associate the searched courses with. ' +
-    "<u>The search is restricted to the selected program's catalog.</u>",
+    '<div style="white-space: pre-wrap;">' +
+    'Which program to associate the searched courses with.' +
+    "\n<u>The search is restricted to the selected program's catalog.</u>" +
+    '</div>',
   hideOnClick: false
 };
 
@@ -26,8 +28,8 @@ export const fieldSelectorTooltipConfig: Partial<Props> = {
   content:
     '<div style="white-space: pre-wrap;">' +
     'Which part of the course to search on.' +
-    '\n\n<strong>Course ID: </strong>The ID of the course (e.g. "CPE101"). ' +
-    'Note that <u>there is no space</u> in the course ID.' +
+    '\n\n<strong>Course ID: </strong>The ID of the course (e.g. "CPE101").' +
+    '\nNote that <u>there is no space</u> in the course ID.' +
     '\n\n<strong>Course Name: </strong>The name of the course' +
     '\n(e.g. "Fundamentals of Computer Science").' +
     '</div>',

--- a/src/lib/client/config/catalogSearchConfigClient.ts
+++ b/src/lib/client/config/catalogSearchConfigClient.ts
@@ -8,22 +8,17 @@ export const BOOLEAN_SEARCH_OPERATORS_REGEX = new RegExp(/[@+\-><()~*"]/);
 
 // search tooltip configs
 export const programSelectorTooltipConfig: Partial<Props> = {
-  arrow: false,
   placement: 'right-start',
-  theme: 'light-border',
   allowHTML: true,
   content:
     '<div style="white-space: pre-wrap;">' +
     'Which program to associate the searched courses with.' +
     "\n<u>The search is restricted to the selected program's catalog.</u>" +
-    '</div>',
-  hideOnClick: false
+    '</div>'
 };
 
 export const fieldSelectorTooltipConfig: Partial<Props> = {
-  arrow: false,
   placement: 'right-start',
-  theme: 'light-border',
   allowHTML: true,
   content:
     '<div style="white-space: pre-wrap;">' +
@@ -32,14 +27,11 @@ export const fieldSelectorTooltipConfig: Partial<Props> = {
     '\nNote that <u>there is no space</u> in the course ID.' +
     '\n\n<strong>Course Name: </strong>The name of the course' +
     '\n(e.g. "Fundamentals of Computer Science").' +
-    '</div>',
-  hideOnClick: false
+    '</div>'
 };
 
 export const searchHelpTooltipConfig: Partial<Props> = {
-  arrow: false,
   placement: 'bottom',
-  theme: 'light-border',
   allowHTML: true,
   content:
     '<div style="white-space: pre-wrap;">' +
@@ -47,6 +39,5 @@ export const searchHelpTooltipConfig: Partial<Props> = {
     '\n\n1. Make sure your query is spelled correctly (searches are not case sensitive). The search tool does not support misspelled queries.' +
     '\n\n2. If you are searching on Course ID, ensure that there are no spaces in between the letters and numbers of the ID.' +
     "\n\n3. Verify that the course you are trying to add is in the selected Program's catalog. Only courses from this catalog are displayed in search results." +
-    '</div>',
-  hideOnClick: false
+    '</div>'
 };

--- a/src/lib/client/util/courseItemUtil.ts
+++ b/src/lib/client/util/courseItemUtil.ts
@@ -58,12 +58,9 @@ export function buildTermCourseItemsData(
     };
     if (browser) {
       itemData.tooltipParams = {
-        arrow: false,
         placement: 'right-start',
-        theme: 'light-border',
         allowHTML: true,
-        content: generateCourseItemTooltipHTML(computedCourseDisplayValues),
-        hideOnClick: false
+        content: generateCourseItemTooltipHTML(computedCourseDisplayValues)
       };
     }
     items.push(itemData);

--- a/src/lib/client/util/courseItemUtil.ts
+++ b/src/lib/client/util/courseItemUtil.ts
@@ -64,7 +64,6 @@ export function buildTermCourseItemsData(
         theme: 'light-border',
         allowHTML: true,
         content: generateCourseItemTooltipHTML(computedCourseDisplayValues),
-        maxWidth: MAX_TOOLTIP_WIDTH_PX,
         hideOnClick: false
       };
     }

--- a/src/lib/client/util/courseItemUtil.ts
+++ b/src/lib/client/util/courseItemUtil.ts
@@ -1,7 +1,6 @@
 // client utility functions for course cards
 
 import { browser } from '$app/environment';
-import { MAX_TOOLTIP_WIDTH_PX } from '$lib/client/config/uiConfig';
 import { UserDataUpdateChunkType, UserDataUpdateChunkTERM_MODCourseDataFrom } from '$lib/types';
 import {
   getCourseFromCourseCache,

--- a/src/lib/client/util/flowListItemUtil.ts
+++ b/src/lib/client/util/flowListItemUtil.ts
@@ -22,7 +22,6 @@ export function buildFlowListContainerItemsData(
         theme: 'light-border',
         allowHTML: true,
         content: generateFlowListItemTooltipHTML(flowListUIData[idx]),
-        maxWidth: MAX_TOOLTIP_WIDTH_PX,
         hideOnClick: false
       };
     }

--- a/src/lib/client/util/flowListItemUtil.ts
+++ b/src/lib/client/util/flowListItemUtil.ts
@@ -1,5 +1,4 @@
 import { browser } from '$app/environment';
-import { MAX_TOOLTIP_WIDTH_PX } from '$lib/client/config/uiConfig';
 import type { FlowListItemData, FlowListUIData } from '$lib/types';
 
 export function buildFlowListContainerItemsData(

--- a/src/lib/client/util/flowListItemUtil.ts
+++ b/src/lib/client/util/flowListItemUtil.ts
@@ -16,12 +16,9 @@ export function buildFlowListContainerItemsData(
     // can only generate HTML content for tooltip in browser
     if (browser) {
       itemData.tooltipParams = {
-        arrow: false,
         placement: 'right-start',
-        theme: 'light-border',
         allowHTML: true,
-        content: generateFlowListItemTooltipHTML(flowListUIData[idx]),
-        hideOnClick: false
+        content: generateFlowListItemTooltipHTML(flowListUIData[idx])
       };
     }
     items.push(itemData);

--- a/src/lib/client/util/tooltipUtil.ts
+++ b/src/lib/client/util/tooltipUtil.ts
@@ -1,5 +1,13 @@
 import tippy from 'tippy.js';
+import { MAX_TOOLTIP_WIDTH_PX } from '$lib/client/config/uiConfig';
 import type { Props } from 'tippy.js';
+
+function mergeDefaultTooltipParams(params: Partial<Props>): Partial<Props> {
+  return {
+    maxWidth: MAX_TOOLTIP_WIDTH_PX,
+    ...params
+  };
+}
 
 // actions: https://blog.logrocket.com/svelte-actions-introduction/
 export function tooltip(
@@ -9,10 +17,10 @@ export function tooltip(
   update?: (params: Partial<Props>) => void;
   destroy?: () => void;
 } {
-  const tip = tippy(node, params);
+  const tip = tippy(node, mergeDefaultTooltipParams(params));
   return {
     update: (newParams: Partial<Props>) => {
-      tip.setProps(newParams);
+      tip.setProps(mergeDefaultTooltipParams(newParams));
     },
     destroy: () => {
       tip.destroy();

--- a/src/lib/client/util/tooltipUtil.ts
+++ b/src/lib/client/util/tooltipUtil.ts
@@ -5,6 +5,9 @@ import type { Props } from 'tippy.js';
 function mergeDefaultTooltipParams(params: Partial<Props>): Partial<Props> {
   return {
     maxWidth: MAX_TOOLTIP_WIDTH_PX,
+    theme: 'light-border',
+    arrow: false,
+    hideOnClick: false,
     ...params
   };
 }


### PR DESCRIPTION
This PR is a small change that sets default options for tooltips created via the `tooltip` action.

The default options that are currently set are `maxWidth`, `theme`, `arrow`, and `hideOnClick`.

Existing tests pass with these changes.