### PR TITLE
feat: add tooltips to flow editor header buttons

### DIFF
--- a/src/lib/client/config/flowEditorHeaderTooltipConfigClient.ts
+++ b/src/lib/client/config/flowEditorHeaderTooltipConfigClient.ts
@@ -1,0 +1,20 @@
+import type { Props } from 'tippy.js';
+
+// button group tooltip configs
+export const viewingFlowInfoPanelTooltipConfig: Partial<Props> = {
+  placement: 'top',
+  content: 'Show/hide Flow Info Panel',
+  hideOnClick: true
+};
+
+export const flowEditorLeftScrollTooltipConfig: Partial<Props> = {
+  placement: 'top',
+  content: 'Scroll Flow Editor left',
+  hideOnClick: true
+};
+
+export const flowEditorRightScrollTooltipConfig: Partial<Props> = {
+  placement: 'top',
+  content: 'Scroll Flow Editor right',
+  hideOnClick: true
+};

--- a/src/lib/components/Flows/FlowEditor/FlowEditorHeader.svelte
+++ b/src/lib/components/Flows/FlowEditor/FlowEditorHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Fa from 'svelte-fa';
+  import { tooltip } from '$lib/client/util/tooltipUtil';
   import { viewingFlowInfoPanel } from '$lib/client/stores/UIDataStore';
   import { createEventDispatcher } from 'svelte';
   import { faArrowLeft, faArrowRight, faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
@@ -7,6 +8,11 @@
     TERM_CONTAINER_WIDTH_PX,
     FLOW_EDITOR_HEADER_PADDING_PX
   } from '$lib/client/config/uiConfig';
+  import {
+    viewingFlowInfoPanelTooltipConfig,
+    flowEditorLeftScrollTooltipConfig,
+    flowEditorRightScrollTooltipConfig
+  } from '$lib/client/config/flowEditorHeaderTooltipConfigClient';
 
   export let name: string;
   export let enableLeftScrollArrow = false;
@@ -34,6 +40,7 @@
       <button
         class="btn btn-sm btn-square btn-ghost"
         aria-label="show/hide flow info panel"
+        use:tooltip={viewingFlowInfoPanelTooltipConfig}
         on:click={() => ($viewingFlowInfoPanel = !$viewingFlowInfoPanel)}
       >
         <Fa icon={$viewingFlowInfoPanel ? faEye : faEyeSlash} />
@@ -42,6 +49,7 @@
         class="btn btn-sm btn-square btn-ghost"
         aria-label="flow editor left scroll"
         disabled={!enableLeftScrollArrow}
+        use:tooltip={flowEditorLeftScrollTooltipConfig}
         on:click={() => dispatch('leftScrollArrowClick')}
       >
         <Fa icon={faArrowLeft} />
@@ -50,6 +58,7 @@
         class="btn btn-sm btn-square btn-ghost"
         aria-label="flow editor right scroll"
         disabled={!enableRightScrollArrow}
+        use:tooltip={flowEditorRightScrollTooltipConfig}
         on:click={() => dispatch('rightScrollArrowClick')}
       >
         <Fa icon={faArrowRight} />

--- a/tests/page/flows/flowViewerTests.test.ts
+++ b/tests/page/flows/flowViewerTests.test.ts
@@ -393,6 +393,8 @@ test.describe('flowchart viewer tests', () => {
     ).not.toBeInViewport();
 
     // do the right scroll
+    await page.getByLabel('flow editor right scroll').hover();
+    await expect(page.getByText('Scroll Flow Editor right')).toBeInViewport();
     await page.getByLabel('flow editor right scroll').click();
     await expect(page.getByLabel('flow editor left scroll')).toBeEnabled();
     await expect(page.getByLabel('flow editor right scroll')).toBeDisabled();
@@ -452,6 +454,8 @@ test.describe('flowchart viewer tests', () => {
     ).not.toBeInViewport();
 
     // do the left scroll
+    await page.getByLabel('flow editor left scroll').hover();
+    await expect(page.getByText('Scroll Flow Editor left')).toBeInViewport();
     await page.getByLabel('flow editor left scroll').click();
     await expect(page.getByLabel('flow editor right scroll')).toBeEnabled();
     await expect(page.getByLabel('flow editor left scroll')).toBeDisabled();
@@ -762,6 +766,8 @@ test.describe('flowchart viewer tests', () => {
     await expect(page.getByLabel('show/hide flow info panel')).toBeEnabled();
 
     // now hide flow info panel and expect it to be gone
+    await page.getByLabel('show/hide flow info panel').hover();
+    await expect(page.getByText('Show/Hide Flow Info Panel')).toBeInViewport();
     await page.getByLabel('show/hide flow info panel').click();
     await expect(page.locator(FLOW_LIST_ITEM_SELECTOR)).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'New Flow' })).not.toBeVisible();


### PR DESCRIPTION
This PR adds tooltips to the three buttons in the `FlowEditorHeader` to explain their functionality, as their function may be unintuitive for new users.

Tests were added to verify this functionality.