### PR TITLE
chore: bump svelte-dnd-action to 0.9.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6751,9 +6751,9 @@
       }
     },
     "node_modules/svelte-dnd-action": {
-      "version": "0.9.28",
-      "resolved": "https://registry.npmjs.org/svelte-dnd-action/-/svelte-dnd-action-0.9.28.tgz",
-      "integrity": "sha512-IN2oxIxzHuW59B1nTwWhSzb55D5k6RbJjXUQsh1gtfzl+CkXKEz4oiZgEocCvbcOroq0ZgDn8VOLh3f2KGYTWQ==",
+      "version": "0.9.33",
+      "resolved": "https://registry.npmjs.org/svelte-dnd-action/-/svelte-dnd-action-0.9.33.tgz",
+      "integrity": "sha512-sX9ML9yrjw/f5zTS4psfGZk9B20IYZ1Q9f9Zb/YcH7hXPBISGR8vu87VxKvg99AYOVKbkjJAQoDjJGgC7SorVw==",
       "dev": true,
       "peerDependencies": {
         "svelte": ">=3.23.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,7 +46,10 @@ const config: PlaywrightTestConfig = {
         deviceScaleFactor: 1
       }
     }
-  ]
+  ],
+  use: {
+    video: 'retain-on-failure'
+  }
 };
 
 export default config;

--- a/src/lib/components/common/MutableForEachContainer.svelte
+++ b/src/lib/components/common/MutableForEachContainer.svelte
@@ -26,7 +26,7 @@
   // drag and drop props
   export let dndType = '';
   export let dropFromOthersDisabled = false;
-  export let flipDurationMs = 300;
+  export let flipDurationMs = 200;
 
   // create 'internal items' so that we can freely mutate the IDs in the itemsData objects
   let internalItemsData: MutableForEachContainerItemInternal[] = [];
@@ -68,7 +68,8 @@
         items: internalItemsData,
         dropTargetStyle: {},
         type: dndType,
-        dropFromOthersDisabled
+        dropFromOthersDisabled,
+        flipDurationMs
       }}
       on:consider={handleConsider}
       on:finalize={handleFinalize}

--- a/src/lib/components/common/MutableForEachContainer.svelte
+++ b/src/lib/components/common/MutableForEachContainer.svelte
@@ -53,6 +53,8 @@
     internalItemsData = e.detail.items;
   }
   function handleFinalize(e: CustomEvent<DndEvent<MutableForEachContainerItemInternal>>) {
+    internalItemsData = e.detail.items;
+
     // only emit the data items, not the internal ones
     const emitItemsData = e.detail.items.map((internalItem) => internalItem.item);
     dispatch('itemsReorder', emitItemsData);

--- a/tests/util/frontendInteractionUtil.ts
+++ b/tests/util/frontendInteractionUtil.ts
@@ -48,15 +48,15 @@ export async function dragAndDrop(
   // if tests are not performing as expected, bump up drag resolution via step count
   const steps = (testInfo.project.name === 'webkit' ? 2000 : 50) * 2 ** testInfo.retry;
   await page.mouse.move(destX, destY, { steps });
+
+  // wait for at least flipDurationMs in MutableForEachContainer
+  // adjust as appropriate (same with second timeout)
+  await page.waitForTimeout(300);
+
   await page.mouse.up();
 
-  // need this to 'reset the drag' for some reason (maybe svelte-dnd-action quirk, see traces w/o this)
-  if (doEndClick) {
-    await locatorToDrag.click();
-  }
-
   // if tests are not performing as expected, bump up timeout to let elements "settle" in headless mode
-  await page.waitForTimeout(100);
+  await page.waitForTimeout(300);
 }
 
 export async function skipWelcomeMessage(page: Page) {


### PR DESCRIPTION
This PR bumps the dependency `svelte-dnd-action` to `0.9.33`.

This is necessary as a PR because some changes had to be made for PolyFlowBuilder to work with this updated version.

Additionally, video recording for test failures is added in this PR.

Existing tests were updated to work with the new version.