### PR TITLE
Update Flowchart total units when terms are removed

### DIFF
--- a/src/lib/common/util/flowTermUtilCommon.ts
+++ b/src/lib/common/util/flowTermUtilCommon.ts
@@ -1,4 +1,6 @@
-import { FLOW_TERM_COUNT_MAX } from '../config/flowDataConfig';
+import { ObjectMap } from '$lib/common/util/ObjectMap';
+import { computeTotalUnits } from '$lib/common/util/unitCounterUtilCommon';
+import { FLOW_TERM_COUNT_MAX } from '$lib/common/config/flowDataConfig';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 
 export function performAddTerms(termAddIdxs: number[], flowchart: Flowchart): Flowchart {
@@ -30,6 +32,7 @@ export function performDeleteTerms(termDeleteIdxs: number[], flowchart: Flowchar
   newFlowchart.termData = newFlowchart.termData.filter(
     (termData) => !termDeleteIdxs.includes(termData.tIndex)
   );
+  newFlowchart.unitTotal = computeTotalUnits(newFlowchart.termData, new ObjectMap(), new Map());
   return newFlowchart;
 }
 

--- a/src/lib/components/Flows/modals/DeleteTermsModal.svelte
+++ b/src/lib/components/Flows/modals/DeleteTermsModal.svelte
@@ -50,6 +50,7 @@
       class="w-full select select-bordered"
       multiple
       name="deleteTerms"
+      aria-label="select flowchart terms to delete"
       size="15"
       bind:value={selectedTermValues}
     >

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
@@ -281,4 +281,16 @@ test.describe('remove flowchart terms tests', () => {
       'ERROR: The server reported an error on data modification. This means that your most recent changes were not saved. Please reload the page to ensure that no data has been lost.'
     );
   });
+
+  test('user able to delete one flowchart term', async ({ page }) => {
+    await performRemoveTermsTest(
+      page,
+      0,
+      ['Summer 2020', 'Fall 2020', 'Winter 2021', 'Spring 2021', 'Summer 2021', 'Fall 2021'],
+      ['Summer 2020']
+    );
+  });
+
+  // TODO: Test for deleting multiple terms consecutively
+  // TODO: test for deleting multiple terms non-consecutively
 });

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
@@ -57,4 +57,16 @@ test.describe('remove flowchart terms tests', () => {
   test.afterAll(async () => {
     await deleteUser(userEmail);
   });
+
+  test('remove flowchart terms default state correct', async ({ page }) => {
+    // make sure we can open modal when a flowcahrt is selected and that it's currently closed
+
+    // cannot access when no flowchart is selected
+    await expect(page.getByText('Remove Flowchart Terms')).not.toBeVisible();
+    await expect(
+      page.getByText('Actions', {
+        exact: true
+      })
+    ).not.toBeEnabled();
+  });
 });

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
@@ -182,7 +182,6 @@ async function verifyRemoveTermFailure(
 }
 
 test.describe('remove flowchart terms tests', () => {
-  test.describe.configure({ mode: 'serial' });
   const prisma = new PrismaClient();
   let userId: string;
   let userEmail: string;
@@ -207,7 +206,7 @@ test.describe('remove flowchart terms tests', () => {
     userId = id;
 
     // populate some flowcharts
-    await populateFlowcharts(prisma, userId, 2, [
+    await populateFlowcharts(prisma, userId, 3, [
       {
         idx: 0,
         info: {
@@ -217,6 +216,13 @@ test.describe('remove flowchart terms tests', () => {
       },
       {
         idx: 1,
+        info: {
+          longTermCount: 0,
+          termCount: 10
+        }
+      },
+      {
+        idx: 2,
         info: {
           longTermCount: 0,
           termCount: 10
@@ -314,8 +320,11 @@ test.describe('remove flowchart terms tests', () => {
   test('user able to delete multiple non-consecutive flowchart terms', async ({ page }) => {
     await performRemoveTermsTest(
       page,
-      1,
+      2,
       [
+        'Summer 2020',
+        'Fall 2020',
+        'Winter 2021',
         'Spring 2021',
         'Summer 2021',
         'Fall 2021',

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
@@ -291,6 +291,25 @@ test.describe('remove flowchart terms tests', () => {
     );
   });
 
-  // TODO: Test for deleting multiple terms consecutively
+  test('user able to delete multiple consecutive flowchart terms', async ({ page }) => {
+    await performRemoveTermsTest(
+      page,
+      1,
+      [
+        'Summer 2020',
+        'Fall 2020',
+        'Winter 2021',
+        'Spring 2021',
+        'Summer 2021',
+        'Fall 2021',
+        'Winter 2022',
+        'Spring 2022',
+        'Summer 2022',
+        'Fall 2022'
+      ],
+      ['Summer 2020', 'Fall 2020', 'Winter 2021']
+    );
+  });
+
   // TODO: test for deleting multiple terms non-consecutively
 });

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
@@ -269,4 +269,16 @@ test.describe('remove flowchart terms tests', () => {
       'ERROR: You were not authorized to perform the most recent flow data change. Please refresh the page and re-authenticate.'
     );
   });
+
+  test('500 case handled properly', async ({ page }) => {
+    await verifyRemoveTermFailure(
+      page,
+      0,
+      ['Summer 2020', 'Fall 2020', 'Winter 2021', 'Spring 2021', 'Summer 2021', 'Fall 2021'],
+      ['Summer 2020'],
+      500,
+      'An error occurred while updating user flowcharts, please try again a bit later.',
+      'ERROR: The server reported an error on data modification. This means that your most recent changes were not saved. Please reload the page to ensure that no data has been lost.'
+    );
+  });
 });

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
@@ -257,4 +257,16 @@ test.describe('remove flowchart terms tests', () => {
       'ERROR: The server reported an error on data modification. This means that your most recent changes were not saved. Please reload the page to ensure that no data has been lost.'
     );
   });
+
+  test('401 case handled properly', async ({ page }) => {
+    await verifyRemoveTermFailure(
+      page,
+      0,
+      ['Summer 2020', 'Fall 2020', 'Winter 2021', 'Spring 2021', 'Summer 2021', 'Fall 2021'],
+      ['Summer 2020'],
+      401,
+      'Request was unauthenticated. Please authenticate and try again.',
+      'ERROR: You were not authorized to perform the most recent flow data change. Please refresh the page and re-authenticate.'
+    );
+  });
 });

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
@@ -34,7 +34,7 @@ async function verifyUIChangesAfterRemoveTerms(
 
   // verify total flowchart units from termContainers matches total flowchart units from footer
   const totalUnitCountFromTerms = (await page.locator('.termContainerFooter h3').allInnerTexts())
-    .map((unitFooterText) => unitFooterText.split(' ')[0])
+    .map((termFooterText) => termFooterText.split(' ')[0])
     .reduce((acc, curVal) => incrementRangedUnits(acc, curVal), '0');
   const totalUnitCountFromFooter = (await page.locator('#flowEditorFooterTotal').innerText())
     .split(' ')

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+import { PrismaClient } from '@prisma/client';
+import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
+import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { createUser, deleteUser } from '$lib/server/db/user';
+import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+
+test.describe('remove flowchart terms tests', () => {
+  test.describe.configure({ mode: 'serial' });
+  const prisma = new PrismaClient();
+  let userId: string;
+  let userEmail: string;
+
+  // eslint-disable-next-line no-empty-pattern
+  test.beforeAll(async ({}, testInfo) => {
+    // create account
+    userEmail = getUserEmailString(
+      'pfb_test_flowsPage_remove_terms_modal_playwright@test.com',
+      testInfo
+    );
+    const id = await createUser({
+      email: userEmail,
+      username: 'test',
+      password: 'test'
+    });
+
+    if (!id) {
+      throw new Error('userId is null');
+    }
+
+    userId = id;
+
+    // populate some flowcharts
+    await populateFlowcharts(prisma, userId, 2, [
+      {
+        idx: 0,
+        info: {
+          longTermCount: 0,
+          termCount: 6
+        }
+      },
+      {
+        idx: 1,
+        info: {
+          longTermCount: 0,
+          termCount: 10
+        }
+      }
+    ]);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await skipWelcomeMessage(page);
+    await performLoginFrontend(page, userEmail, 'test');
+  });
+
+  test.afterAll(async () => {
+    await deleteUser(userEmail);
+  });
+});

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
@@ -311,5 +311,20 @@ test.describe('remove flowchart terms tests', () => {
     );
   });
 
-  // TODO: test for deleting multiple terms non-consecutively
+  test('user able to delete multiple non-consecutive flowchart terms', async ({ page }) => {
+    await performRemoveTermsTest(
+      page,
+      1,
+      [
+        'Spring 2021',
+        'Summer 2021',
+        'Fall 2021',
+        'Winter 2022',
+        'Spring 2022',
+        'Summer 2022',
+        'Fall 2022'
+      ],
+      ['Spring 2021', 'Spring 2022', 'Fall 2022']
+    );
+  });
 });


### PR DESCRIPTION
This PR fixes issue #100 where we were seeing that the Flowchart units were not being updated when flowchart terms were removed.

Tests were added to cover this functionality, to ensure it doesn't come up again in the future.