### PR TITLE
feat: use $test path alias in testing files

### DIFF
--- a/src/lib/client/util/unitCounterUtilClient.test.ts
+++ b/src/lib/client/util/unitCounterUtilClient.test.ts
@@ -1,7 +1,7 @@
 import * as apiDataConfig from '$lib/server/config/apiDataConfig';
 import { ObjectMap } from '$lib/common/util/ObjectMap';
 import { computeGroupUnits } from '$lib/client/util/unitCounterUtilClient';
-import { TEST_FLOWCHART_SINGLE_PROGRAM_1 } from '../../../../tests/util/testFlowcharts';
+import { TEST_FLOWCHART_SINGLE_PROGRAM_1 } from '$test/util/testFlowcharts';
 
 // init api data
 await apiDataConfig.init();

--- a/src/lib/common/util/unitCounterUtilCommon.test.ts
+++ b/src/lib/common/util/unitCounterUtilCommon.test.ts
@@ -1,7 +1,7 @@
 import * as apiDataConfig from '$lib/server/config/apiDataConfig';
 import { ObjectMap } from '$lib/common/util/ObjectMap';
-import { createCourseCacheFromEntries } from '../../../../tests/util/courseCacheUtil';
-import { TEST_FLOWCHART_SINGLE_PROGRAM_1 } from '../../../../tests/util/testFlowcharts';
+import { createCourseCacheFromEntries } from '$test/util/courseCacheUtil';
+import { TEST_FLOWCHART_SINGLE_PROGRAM_1 } from '$test/util/testFlowcharts';
 import {
   computeTermUnits,
   computeTotalUnits,

--- a/src/lib/components/Flows/FlowEditor/FlowEditor.test.ts
+++ b/src/lib/components/Flows/FlowEditor/FlowEditor.test.ts
@@ -1,8 +1,8 @@
 import * as apiDataConfig from '$lib/server/config/apiDataConfig';
 import { vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
-import { TEST_FLOWCHART_SINGLE_PROGRAM_2 } from '../../../../../tests/util/testFlowcharts';
-import { mockCourseCacheStore, mockProgramCacheStore } from '../../../../../tests/util/storeMocks';
+import { TEST_FLOWCHART_SINGLE_PROGRAM_2 } from '$test/util/testFlowcharts';
+import { mockCourseCacheStore, mockProgramCacheStore } from '$test/util/storeMocks';
 
 // this import NEEDS to be down here or else the vi.mock() call that we're using to mock
 // the programCache and courseCache stores FAILS!! because vi.mock() MUST be called

--- a/src/lib/components/Flows/FlowEditor/TermContainer.test.ts
+++ b/src/lib/components/Flows/FlowEditor/TermContainer.test.ts
@@ -1,7 +1,7 @@
 import * as apiDataConfig from '$lib/server/config/apiDataConfig';
 import { render, screen } from '@testing-library/svelte';
-import { TEST_FLOWCHART_SINGLE_PROGRAM_2 } from '../../../../../tests/util/testFlowcharts';
-import { mockCourseCacheStore, mockProgramCacheStore } from '../../../../../tests/util/storeMocks';
+import { TEST_FLOWCHART_SINGLE_PROGRAM_2 } from '$test/util/testFlowcharts';
+import { mockCourseCacheStore, mockProgramCacheStore } from '$test/util/storeMocks';
 
 // load necessary API data
 await apiDataConfig.init();

--- a/src/lib/components/Flows/FlowViewer.test.ts
+++ b/src/lib/components/Flows/FlowViewer.test.ts
@@ -1,8 +1,8 @@
 import * as apiDataConfig from '$lib/server/config/apiDataConfig';
 import { vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
-import { TEST_FLOWCHART_SINGLE_PROGRAM_2 } from '../../../../tests/util/testFlowcharts';
-import { mockCourseCacheStore, mockProgramCacheStore } from '../../../../tests/util/storeMocks';
+import { TEST_FLOWCHART_SINGLE_PROGRAM_2 } from '$test/util/testFlowcharts';
+import { mockCourseCacheStore, mockProgramCacheStore } from '$test/util/storeMocks';
 
 await apiDataConfig.init();
 

--- a/src/lib/components/Flows/modals/AddTermsModal.test.ts
+++ b/src/lib/components/Flows/modals/AddTermsModal.test.ts
@@ -1,12 +1,12 @@
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
-import { TEST_FLOWCHART_SINGLE_PROGRAM_2 } from '../../../../../tests/util/testFlowcharts';
+import { TEST_FLOWCHART_SINGLE_PROGRAM_2 } from '$test/util/testFlowcharts';
 import { act, getAllByRole, queryAllByRole, render, screen } from '@testing-library/svelte';
 import {
   mockModalOpenStore,
   mockSelectedFlowIndexStore,
   mockUserFlowchartsStore
-} from '../../../../../tests/util/storeMocks';
+} from '$test/util/storeMocks';
 
 // this import NEEDS to be down here or else the vi.mock() call that we're using to mock
 // the addTermsModalOpenStore FAILS!! because vi.mock() MUST be called

--- a/src/lib/components/Flows/modals/NewFlowModal.test.ts
+++ b/src/lib/components/Flows/modals/NewFlowModal.test.ts
@@ -11,7 +11,7 @@ import {
   mockMajorOptionsCacheStore,
   mockAvailableFlowchartCatalogsStore,
   mockAvailableFlowchartStartYearsStore
-} from '../../../../../tests/util/storeMocks';
+} from '$test/util/storeMocks';
 
 // this import NEEDS to be down here or else the vi.mock() call that we're using to mock
 // the newFlowModalOpenStore FAILS!! because vi.mock() MUST be called

--- a/src/lib/components/common/FlowPropertiesSelector/Component.test.ts
+++ b/src/lib/components/common/FlowPropertiesSelector/Component.test.ts
@@ -9,7 +9,7 @@ import {
   mockMajorOptionsCacheStore,
   mockAvailableFlowchartCatalogsStore,
   mockAvailableFlowchartStartYearsStore
-} from '../../../../../tests/util/storeMocks';
+} from '$test/util/storeMocks';
 import type { UserEvent } from '@testing-library/user-event';
 
 // load necessary API data

--- a/src/lib/components/common/FlowPropertiesSelector/ProgramSelector.test.ts
+++ b/src/lib/components/common/FlowPropertiesSelector/ProgramSelector.test.ts
@@ -8,7 +8,7 @@ import {
   mockConcOptionsCacheStore,
   mockMajorOptionsCacheStore,
   mockAvailableFlowchartCatalogsStore
-} from '../../../../../tests/util/storeMocks';
+} from '$test/util/storeMocks';
 import type { Program } from '@prisma/client';
 
 // see https://github.com/davipon/svelte-component-test-recipes

--- a/src/lib/server/util/courseCacheUtil.test.ts
+++ b/src/lib/server/util/courseCacheUtil.test.ts
@@ -4,7 +4,7 @@ import { generateCourseCacheFlowcharts } from '$lib/server/util/courseCacheUtil'
 import {
   createCourseCacheFromEntries,
   verifyCourseCacheStrictEquality
-} from '../../../../tests/util/courseCacheUtil';
+} from '$test/util/courseCacheUtil';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { ProgramCache } from '$lib/types';
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -24,6 +24,9 @@ const config = {
     },
     version: {
       name: execSync('git rev-parse --short HEAD').toString().trim()
+    },
+    alias: {
+      $tests: './tests'
     }
   }
 };

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -26,7 +26,7 @@ const config = {
       name: execSync('git rev-parse --short HEAD').toString().trim()
     },
     alias: {
-      $tests: './tests'
+      $test: './tests'
     }
   }
 };

--- a/tests/api/generateFlowchartApiTests/expectedResponsePayloads.ts
+++ b/tests/api/generateFlowchartApiTests/expectedResponsePayloads.ts
@@ -1,5 +1,5 @@
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
-import { createCourseCacheFromEntries } from 'tests/util/courseCacheUtil';
+import { createCourseCacheFromEntries } from '../../util/courseCacheUtil';
 
 export const responsePayload1 = {
   generatedFlowchart: {

--- a/tests/api/generateFlowchartApiTests/expectedResponsePayloads.ts
+++ b/tests/api/generateFlowchartApiTests/expectedResponsePayloads.ts
@@ -1,5 +1,5 @@
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
-import { createCourseCacheFromEntries } from '../../util/courseCacheUtil';
+import { createCourseCacheFromEntries } from '$test/util/courseCacheUtil';
 
 export const responsePayload1 = {
   generatedFlowchart: {

--- a/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
+++ b/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
@@ -3,15 +3,15 @@ import { ObjectMap } from '$lib/common/util/ObjectMap';
 import { expect, test } from '@playwright/test';
 import { FLOW_NAME_MAX_LENGTH } from '$lib/common/config/flowDataConfig';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { deleteObjectProperties } from '../../util/testUtil';
+import { deleteObjectProperties } from '$test/util/testUtil';
 import { flowchartValidationSchema } from '$lib/common/schema/flowchartSchema';
-import { verifyCourseCacheStrictEquality } from '../../util/courseCacheUtil';
-import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
+import { verifyCourseCacheStrictEquality } from '$test/util/courseCacheUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 import {
   responsePayload1,
   responsePayload2,
   responsePayload3
-} from '../../api/generateFlowchartApiTests/expectedResponsePayloads';
+} from '$test/api/generateFlowchartApiTests/expectedResponsePayloads';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { APICourseFull } from '$lib/types/apiDataTypes';
 

--- a/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
+++ b/tests/api/generateFlowchartApiTests/generateFlowchartApiTests.test.ts
@@ -3,15 +3,15 @@ import { ObjectMap } from '$lib/common/util/ObjectMap';
 import { expect, test } from '@playwright/test';
 import { FLOW_NAME_MAX_LENGTH } from '$lib/common/config/flowDataConfig';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { deleteObjectProperties } from 'tests/util/testUtil';
+import { deleteObjectProperties } from '../../util/testUtil';
 import { flowchartValidationSchema } from '$lib/common/schema/flowchartSchema';
-import { verifyCourseCacheStrictEquality } from 'tests/util/courseCacheUtil';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+import { verifyCourseCacheStrictEquality } from '../../util/courseCacheUtil';
+import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
 import {
   responsePayload1,
   responsePayload2,
   responsePayload3
-} from 'tests/api/generateFlowchartApiTests/expectedResponsePayloads';
+} from '../../api/generateFlowchartApiTests/expectedResponsePayloads';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { APICourseFull } from '$lib/types/apiDataTypes';
 

--- a/tests/api/getAvailableCatalogsTests.test.ts
+++ b/tests/api/getAvailableCatalogsTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 
 test.describe('getAvailableCatalogsTests tests', () => {
   let userEmail: string;

--- a/tests/api/getAvailableCatalogsTests.test.ts
+++ b/tests/api/getAvailableCatalogsTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
 
 test.describe('getAvailableCatalogsTests tests', () => {
   let userEmail: string;

--- a/tests/api/getAvailableStartYearsTests.test.ts
+++ b/tests/api/getAvailableStartYearsTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
 
 test.describe('getAvailableStartYears tests', () => {
   let userEmail: string;

--- a/tests/api/getAvailableStartYearsTests.test.ts
+++ b/tests/api/getAvailableStartYearsTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 
 test.describe('getAvailableStartYears tests', () => {
   let userEmail: string;

--- a/tests/api/getUserFlowchartsTests.test.ts
+++ b/tests/api/getUserFlowchartsTests.test.ts
@@ -4,12 +4,12 @@ import { PrismaClient } from '@prisma/client';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
-import { cloneAndDeleteNestedProperty } from '../util/testUtil';
+import { cloneAndDeleteNestedProperty } from '$test/util/testUtil';
 import {
   createCourseCacheFromEntries,
   verifyCourseCacheStrictEquality
-} from '../util/courseCacheUtil';
-import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
+} from '$test/util/courseCacheUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { APICourseFull } from '$lib/types';
 

--- a/tests/api/getUserFlowchartsTests.test.ts
+++ b/tests/api/getUserFlowchartsTests.test.ts
@@ -4,12 +4,12 @@ import { PrismaClient } from '@prisma/client';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
-import { cloneAndDeleteNestedProperty } from 'tests/util/testUtil';
+import { cloneAndDeleteNestedProperty } from '../util/testUtil';
 import {
   createCourseCacheFromEntries,
   verifyCourseCacheStrictEquality
-} from 'tests/util/courseCacheUtil';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+} from '../util/courseCacheUtil';
+import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { APICourseFull } from '$lib/types';
 

--- a/tests/api/loginApiTests.test.ts
+++ b/tests/api/loginApiTests.test.ts
@@ -1,6 +1,6 @@
 import { createUser } from '$lib/server/db/user';
 import { PrismaClient } from '@prisma/client';
-import { getUserEmailString } from 'tests/util/userTestUtil';
+import { getUserEmailString } from '../util/userTestUtil';
 import { expect, request, test } from '@playwright/test';
 import type { APIRequestContext } from '@playwright/test';
 

--- a/tests/api/loginApiTests.test.ts
+++ b/tests/api/loginApiTests.test.ts
@@ -1,6 +1,6 @@
 import { createUser } from '$lib/server/db/user';
 import { PrismaClient } from '@prisma/client';
-import { getUserEmailString } from '../util/userTestUtil';
+import { getUserEmailString } from '$test/util/userTestUtil';
 import { expect, request, test } from '@playwright/test';
 import type { APIRequestContext } from '@playwright/test';
 

--- a/tests/api/queryAvailableMajorsTests.test.ts
+++ b/tests/api/queryAvailableMajorsTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
 
 test.describe('queryAvailableMajors tests', () => {
   let userEmail: string;

--- a/tests/api/queryAvailableMajorsTests.test.ts
+++ b/tests/api/queryAvailableMajorsTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 
 test.describe('queryAvailableMajors tests', () => {
   let userEmail: string;

--- a/tests/api/queryAvailableProgramsTests.test.ts
+++ b/tests/api/queryAvailableProgramsTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
 
 test.describe('queryAvailableProgramsTests tests', () => {
   let userEmail: string;

--- a/tests/api/queryAvailableProgramsTests.test.ts
+++ b/tests/api/queryAvailableProgramsTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 
 test.describe('queryAvailableProgramsTests tests', () => {
   let userEmail: string;

--- a/tests/api/registerApiTests.test.ts
+++ b/tests/api/registerApiTests.test.ts
@@ -1,6 +1,6 @@
 import { deleteUser } from '$lib/server/db/user';
 import { expect, test } from '@playwright/test';
-import { getUserEmailString } from 'tests/util/userTestUtil';
+import { getUserEmailString } from '../util/userTestUtil';
 
 test.describe('register api tests', () => {
   test.describe.configure({ mode: 'serial' });

--- a/tests/api/registerApiTests.test.ts
+++ b/tests/api/registerApiTests.test.ts
@@ -1,6 +1,6 @@
 import { deleteUser } from '$lib/server/db/user';
 import { expect, test } from '@playwright/test';
-import { getUserEmailString } from '../util/userTestUtil';
+import { getUserEmailString } from '$test/util/userTestUtil';
 
 test.describe('register api tests', () => {
   test.describe.configure({ mode: 'serial' });

--- a/tests/api/resetPasswordApiTests.test.ts
+++ b/tests/api/resetPasswordApiTests.test.ts
@@ -1,7 +1,7 @@
-import { createToken } from '../util/tokenTestUtil';
+import { createToken } from '$test/util/tokenTestUtil';
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { getUserEmailString } from '../util/userTestUtil';
+import { getUserEmailString } from '$test/util/userTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
 
 test.describe('reset password api tests', () => {

--- a/tests/api/resetPasswordApiTests.test.ts
+++ b/tests/api/resetPasswordApiTests.test.ts
@@ -1,7 +1,7 @@
-import { createToken } from 'tests/util/tokenTestUtil';
+import { createToken } from '../util/tokenTestUtil';
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { getUserEmailString } from 'tests/util/userTestUtil';
+import { getUserEmailString } from '../util/userTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
 
 test.describe('reset password api tests', () => {

--- a/tests/api/searchCatalogApiTests.test.ts
+++ b/tests/api/searchCatalogApiTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 
 test.describe('searchCatalog API tests', () => {
   let userEmail: string;

--- a/tests/api/searchCatalogApiTests.test.ts
+++ b/tests/api/searchCatalogApiTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '../util/userTestUtil';
 
 test.describe('searchCatalog API tests', () => {
   let userEmail: string;

--- a/tests/api/updateUserFlowchartsApiTests/flowDeleteApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowDeleteApiTests.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { populateFlowcharts } from '../../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache } from '$lib/types/apiDataTypes';
 

--- a/tests/api/updateUserFlowchartsApiTests/flowDeleteApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowDeleteApiTests.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from '../../util/userDataTestUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes';
-import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache } from '$lib/types/apiDataTypes';
 

--- a/tests/api/updateUserFlowchartsApiTests/flowListChangeApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowListChangeApiTests.test.ts
@@ -1,10 +1,10 @@
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { populateFlowcharts } from '../../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache } from '$lib/types/apiDataTypes';
 import type { MutateFlowchartData } from '$lib/types/mutateUserDataTypes';

--- a/tests/api/updateUserFlowchartsApiTests/flowListChangeApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowListChangeApiTests.test.ts
@@ -1,10 +1,10 @@
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
-import { populateFlowcharts } from '../../util/userDataTestUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes';
-import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache } from '$lib/types/apiDataTypes';
 import type { MutateFlowchartData } from '$lib/types/mutateUserDataTypes';

--- a/tests/api/updateUserFlowchartsApiTests/flowTermModApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowTermModApiTests.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from '../../util/userDataTestUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 import {
   UserDataUpdateChunkType,
   UserDataUpdateChunkTERM_MODCourseDataFrom

--- a/tests/api/updateUserFlowchartsApiTests/flowTermModApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowTermModApiTests.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { populateFlowcharts } from '../../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
 import {
   UserDataUpdateChunkType,
   UserDataUpdateChunkTERM_MODCourseDataFrom

--- a/tests/api/updateUserFlowchartsApiTests/flowUpsertAllApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowUpsertAllApiTests.test.ts
@@ -1,11 +1,11 @@
 import { v4 as uuid } from 'uuid';
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
-import { populateFlowcharts } from '../../util/userDataTestUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
-import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache } from '$lib/types/apiDataTypes';
 

--- a/tests/api/updateUserFlowchartsApiTests/flowUpsertAllApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/flowUpsertAllApiTests.test.ts
@@ -1,11 +1,11 @@
 import { v4 as uuid } from 'uuid';
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { populateFlowcharts } from '../../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
 import type { Flowchart } from '$lib/common/schema/flowchartSchema';
 import type { CourseCache } from '$lib/types/apiDataTypes';
 

--- a/tests/api/updateUserFlowchartsApiTests/updateUserFlowchartsApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/updateUserFlowchartsApiTests.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
-import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '$test/util/userTestUtil';
 import type { UserDataUpdateChunk } from '$lib/common/schema/mutateUserDataSchema';
 
 test.describe('update user flowchart api tests', () => {

--- a/tests/api/updateUserFlowchartsApiTests/updateUserFlowchartsApiTests.test.ts
+++ b/tests/api/updateUserFlowchartsApiTests/updateUserFlowchartsApiTests.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
 import { UserDataUpdateChunkType } from '$lib/types/mutateUserDataTypes';
 import { CURRENT_FLOW_DATA_VERSION } from '$lib/common/config/flowDataConfig';
-import { getUserEmailString, performLoginBackend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginBackend } from '../../util/userTestUtil';
 import type { UserDataUpdateChunk } from '$lib/common/schema/mutateUserDataSchema';
 
 test.describe('update user flowchart api tests', () => {

--- a/tests/bugfix/gh-issue-38.test.ts
+++ b/tests/bugfix/gh-issue-38.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
-import { skipWelcomeMessage } from '../util/frontendInteractionUtil';
+import { skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from '../util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 
 // bug description: modals fail to open when navigating to the
 // flow editor for the second time (e.g. first time works, then navigate away,

--- a/tests/bugfix/gh-issue-38.test.ts
+++ b/tests/bugfix/gh-issue-38.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
-import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
+import { skipWelcomeMessage } from '../util/frontendInteractionUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../util/userTestUtil';
 
 // bug description: modals fail to open when navigating to the
 // flow editor for the second time (e.g. first time works, then navigate away,

--- a/tests/bugfix/poly-432.test.ts
+++ b/tests/bugfix/poly-432.test.ts
@@ -1,6 +1,6 @@
 import { deleteUser } from '$lib/server/db/user';
 import { expect, test } from '@playwright/test';
-import { getUserEmailString } from '../util/userTestUtil';
+import { getUserEmailString } from '$test/util/userTestUtil';
 
 // bug description: going from /register to /login pages by
 // clicking links (e.g. the "Sign In" link on the /register page)

--- a/tests/bugfix/poly-432.test.ts
+++ b/tests/bugfix/poly-432.test.ts
@@ -1,6 +1,6 @@
 import { deleteUser } from '$lib/server/db/user';
 import { expect, test } from '@playwright/test';
-import { getUserEmailString } from 'tests/util/userTestUtil';
+import { getUserEmailString } from '../util/userTestUtil';
 
 // bug description: going from /register to /login pages by
 // clicking links (e.g. the "Sign In" link on the /register page)

--- a/tests/misc/authGuardTests.test.ts
+++ b/tests/misc/authGuardTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../util/userTestUtil';
 import type { Page } from '@playwright/test';
 
 async function canAccessAboutPage(page: Page) {

--- a/tests/misc/authGuardTests.test.ts
+++ b/tests/misc/authGuardTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from '../util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 import type { Page } from '@playwright/test';
 
 async function canAccessAboutPage(page: Page) {

--- a/tests/page/flows/flowInfoPanel/deleteFlowTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/deleteFlowTests.test.ts
@@ -1,14 +1,14 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
-import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { skipWelcomeMessage } from '../../../util/frontendInteractionUtil';
+import { populateFlowcharts } from '../../../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   FLOW_LIST_ITEM_SELECTED_SELECTOR
-} from 'tests/util/selectorTestUtil';
+} from '../../../util/selectorTestUtil';
 import type { Page } from '@playwright/test';
 
 async function assertCorrectFailureHandling(page: Page, dialogMessage: string) {

--- a/tests/page/flows/flowInfoPanel/deleteFlowTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/deleteFlowTests.test.ts
@@ -1,14 +1,14 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
-import { skipWelcomeMessage } from '../../../util/frontendInteractionUtil';
-import { populateFlowcharts } from '../../../util/userDataTestUtil';
+import { skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   FLOW_LIST_ITEM_SELECTED_SELECTOR
-} from '../../../util/selectorTestUtil';
+} from '$test/util/selectorTestUtil';
 import type { Page } from '@playwright/test';
 
 async function assertCorrectFailureHandling(page: Page, dialogMessage: string) {

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/addFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/addFlowTermsTests.test.ts
@@ -1,16 +1,16 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from '../../../../util/userDataTestUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { incrementRangedUnits } from '$lib/common/util/unitCounterUtilCommon';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { dragAndDrop, skipWelcomeMessage } from '../../../../util/frontendInteractionUtil';
-import { getUserEmailString, performLoginFrontend } from '../../../../util/userTestUtil';
+import { dragAndDrop, skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   TERM_CONTAINER_SELECTOR,
   getTermContainerCourseLocator,
   TERM_CONTAINER_COURSES_SELECTOR
-} from '../../../../util/selectorTestUtil';
+} from '$test/util/selectorTestUtil';
 import type { Page } from '@playwright/test';
 
 async function verifyUIChangesAfterAddTerms(

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/addFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/addFlowTermsTests.test.ts
@@ -1,16 +1,16 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { populateFlowcharts } from '../../../../util/userDataTestUtil';
 import { incrementRangedUnits } from '$lib/common/util/unitCounterUtilCommon';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { dragAndDrop, skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { dragAndDrop, skipWelcomeMessage } from '../../../../util/frontendInteractionUtil';
+import { getUserEmailString, performLoginFrontend } from '../../../../util/userTestUtil';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   TERM_CONTAINER_SELECTOR,
   getTermContainerCourseLocator,
   TERM_CONTAINER_COURSES_SELECTOR
-} from 'tests/util/selectorTestUtil';
+} from '../../../../util/selectorTestUtil';
 import type { Page } from '@playwright/test';
 
 async function verifyUIChangesAfterAddTerms(

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/flowInfoPanelActionsDropdownTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/flowInfoPanelActionsDropdownTests.test.ts
@@ -1,17 +1,17 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
-import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
+import { populateFlowcharts } from '../../../../util/userDataTestUtil';
+import { skipWelcomeMessage } from '../../../../util/frontendInteractionUtil';
 import { FLOW_TERM_COUNT_MAX } from '$lib/common/config/flowDataConfig';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../../../../util/userTestUtil';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   TERM_CONTAINER_SELECTOR,
   getTermContainerCourseLocator,
   TERM_CONTAINER_COURSES_SELECTOR
-} from 'tests/util/selectorTestUtil';
+} from '../../../../util/selectorTestUtil';
 
 // dropdown entries that open modals will be tested separately
 test.describe('FlowInfoPanelActionsDropdown tests', () => {

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/flowInfoPanelActionsDropdownTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/flowInfoPanelActionsDropdownTests.test.ts
@@ -1,17 +1,17 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { getUserFlowcharts } from '$lib/server/db/flowchart';
-import { populateFlowcharts } from '../../../../util/userDataTestUtil';
-import { skipWelcomeMessage } from '../../../../util/frontendInteractionUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
+import { skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
 import { FLOW_TERM_COUNT_MAX } from '$lib/common/config/flowDataConfig';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from '../../../../util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   TERM_CONTAINER_SELECTOR,
   getTermContainerCourseLocator,
   TERM_CONTAINER_COURSES_SELECTOR
-} from '../../../../util/selectorTestUtil';
+} from '$test/util/selectorTestUtil';
 
 // dropdown entries that open modals will be tested separately
 test.describe('FlowInfoPanelActionsDropdown tests', () => {

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
@@ -1,14 +1,11 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { skipWelcomeMessage } from '../../../../util/frontendInteractionUtil';
-import { populateFlowcharts } from '../../../../util/userDataTestUtil';
+import { skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { incrementRangedUnits } from '$lib/common/util/unitCounterUtilCommon';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from '../../../../util/userTestUtil';
-import {
-  FLOW_LIST_ITEM_SELECTOR,
-  TERM_CONTAINER_SELECTOR
-} from '../../../../util/selectorTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
+import { FLOW_LIST_ITEM_SELECTOR, TERM_CONTAINER_SELECTOR } from '$test/util/selectorTestUtil';
 import type { Page } from '@playwright/test';
 
 async function verifyUIChangesAfterRemoveTerms(

--- a/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowInfoPanelActionsDropdown/removeFlowTermsTests.test.ts
@@ -1,11 +1,14 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { skipWelcomeMessage } from '../../../../util/frontendInteractionUtil';
+import { populateFlowcharts } from '../../../../util/userDataTestUtil';
 import { incrementRangedUnits } from '$lib/common/util/unitCounterUtilCommon';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
-import { FLOW_LIST_ITEM_SELECTOR, TERM_CONTAINER_SELECTOR } from 'tests/util/selectorTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../../../../util/userTestUtil';
+import {
+  FLOW_LIST_ITEM_SELECTOR,
+  TERM_CONTAINER_SELECTOR
+} from '../../../../util/selectorTestUtil';
 import type { Page } from '@playwright/test';
 
 async function verifyUIChangesAfterRemoveTerms(

--- a/tests/page/flows/flowInfoPanel/flowListTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowListTests.test.ts
@@ -1,13 +1,13 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from '../../../util/userDataTestUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { dragAndDrop, skipWelcomeMessage } from '../../../util/frontendInteractionUtil';
-import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
+import { dragAndDrop, skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   FLOW_LIST_ITEM_SELECTED_SELECTOR
-} from '../../../util/selectorTestUtil';
+} from '$test/util/selectorTestUtil';
 
 test.describe('flow list tests', () => {
   let userId: string;

--- a/tests/page/flows/flowInfoPanel/flowListTests.test.ts
+++ b/tests/page/flows/flowInfoPanel/flowListTests.test.ts
@@ -1,13 +1,13 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { populateFlowcharts } from '../../../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { dragAndDrop, skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { dragAndDrop, skipWelcomeMessage } from '../../../util/frontendInteractionUtil';
+import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   FLOW_LIST_ITEM_SELECTED_SELECTOR
-} from 'tests/util/selectorTestUtil';
+} from '../../../util/selectorTestUtil';
 
 test.describe('flow list tests', () => {
   let userId: string;

--- a/tests/page/flows/flowViewerTests.test.ts
+++ b/tests/page/flows/flowViewerTests.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { skipWelcomeMessage } from '../../util/frontendInteractionUtil';
-import { populateFlowcharts } from '../../util/userDataTestUtil';
+import { skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { FLOW_LIST_ITEM_SELECTOR } from '../../util/selectorTestUtil';
-import { getUserEmailString, performLoginFrontend } from '../../util/userTestUtil';
+import { FLOW_LIST_ITEM_SELECTOR } from '$test/util/selectorTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 
 test.describe('flowchart viewer tests', () => {
   const prisma = new PrismaClient();

--- a/tests/page/flows/flowViewerTests.test.ts
+++ b/tests/page/flows/flowViewerTests.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { skipWelcomeMessage } from '../../util/frontendInteractionUtil';
+import { populateFlowcharts } from '../../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { FLOW_LIST_ITEM_SELECTOR } from 'tests/util/selectorTestUtil';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { FLOW_LIST_ITEM_SELECTOR } from '../../util/selectorTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../../util/userTestUtil';
 
 test.describe('flowchart viewer tests', () => {
   const prisma = new PrismaClient();

--- a/tests/page/flows/footerTests.test.ts
+++ b/tests/page/flows/footerTests.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { skipWelcomeMessage } from '../../util/frontendInteractionUtil';
-import { populateFlowcharts } from '../../util/userDataTestUtil';
+import { skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { FLOW_LIST_ITEM_SELECTOR } from '../../util/selectorTestUtil';
-import { getUserEmailString, performLoginFrontend } from '../../util/userTestUtil';
+import { FLOW_LIST_ITEM_SELECTOR } from '$test/util/selectorTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 import type { Page } from '@playwright/test';
 
 async function computeTotalUnitDistance(page: Page) {

--- a/tests/page/flows/footerTests.test.ts
+++ b/tests/page/flows/footerTests.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { skipWelcomeMessage } from '../../util/frontendInteractionUtil';
+import { populateFlowcharts } from '../../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { FLOW_LIST_ITEM_SELECTOR } from 'tests/util/selectorTestUtil';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { FLOW_LIST_ITEM_SELECTOR } from '../../util/selectorTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../../util/userTestUtil';
 import type { Page } from '@playwright/test';
 
 async function computeTotalUnitDistance(page: Page) {

--- a/tests/page/flows/headerTests.test.ts
+++ b/tests/page/flows/headerTests.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
+import { skipWelcomeMessage } from '../../util/frontendInteractionUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../../util/userTestUtil';
 
 test.describe('flows page header tests', () => {
   test.describe.configure({ mode: 'serial' });

--- a/tests/page/flows/headerTests.test.ts
+++ b/tests/page/flows/headerTests.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { skipWelcomeMessage } from '../../util/frontendInteractionUtil';
+import { skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from '../../util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 
 test.describe('flows page header tests', () => {
   test.describe.configure({ mode: 'serial' });

--- a/tests/page/flows/modals/newFlowModalTests.test.ts
+++ b/tests/page/flows/modals/newFlowModalTests.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
-import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
+import { skipWelcomeMessage } from '../../../util/frontendInteractionUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
 import type { Page } from '@playwright/test';
 
 async function openModalAndVerifyCorrectState(page: Page) {

--- a/tests/page/flows/modals/newFlowModalTests.test.ts
+++ b/tests/page/flows/modals/newFlowModalTests.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
-import { skipWelcomeMessage } from '../../../util/frontendInteractionUtil';
+import { skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 import type { Page } from '@playwright/test';
 
 async function openModalAndVerifyCorrectState(page: Page) {

--- a/tests/page/flows/modals/welcomeModalTests.test.ts
+++ b/tests/page/flows/modals/welcomeModalTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
 
 test.describe('welcome modal tests', () => {
   let userEmail: string;

--- a/tests/page/flows/modals/welcomeModalTests.test.ts
+++ b/tests/page/flows/modals/welcomeModalTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 
 test.describe('welcome modal tests', () => {
   let userEmail: string;

--- a/tests/page/flows/modifyFlowTermDataTests.test.ts
+++ b/tests/page/flows/modifyFlowTermDataTests.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from '../../util/userDataTestUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { dragAndDrop, skipWelcomeMessage } from '../../util/frontendInteractionUtil';
-import { getUserEmailString, performLoginFrontend } from '../../util/userTestUtil';
+import { dragAndDrop, skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   TERM_CONTAINER_SELECTOR,
   getTermContainerCourseLocator,
   TERM_CONTAINER_COURSES_SELECTOR
-} from '../../util/selectorTestUtil';
+} from '$test/util/selectorTestUtil';
 
 // TODO: include tests that customize courses
 // TODO: include tests that add new courses to terms

--- a/tests/page/flows/modifyFlowTermDataTests.test.ts
+++ b/tests/page/flows/modifyFlowTermDataTests.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { populateFlowcharts } from '../../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { dragAndDrop, skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { dragAndDrop, skipWelcomeMessage } from '../../util/frontendInteractionUtil';
+import { getUserEmailString, performLoginFrontend } from '../../util/userTestUtil';
 import {
   FLOW_LIST_ITEM_SELECTOR,
   TERM_CONTAINER_SELECTOR,
   getTermContainerCourseLocator,
   TERM_CONTAINER_COURSES_SELECTOR
-} from 'tests/util/selectorTestUtil';
+} from '../../util/selectorTestUtil';
 
 // TODO: include tests that customize courses
 // TODO: include tests that add new courses to terms

--- a/tests/page/flows/search/courseSearchOptionsSelectorTests.test.ts
+++ b/tests/page/flows/search/courseSearchOptionsSelectorTests.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { skipWelcomeMessage } from '../../../util/frontendInteractionUtil';
-import { populateFlowcharts } from '../../../util/userDataTestUtil';
+import { skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { FLOW_LIST_ITEM_SELECTOR } from '../../../util/selectorTestUtil';
-import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
+import { FLOW_LIST_ITEM_SELECTOR } from '$test/util/selectorTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 
 // put these tests here instead of w/ component bc this component uses
 // a lot of stores and setting up state is easier when doing it in an e2e env

--- a/tests/page/flows/search/courseSearchOptionsSelectorTests.test.ts
+++ b/tests/page/flows/search/courseSearchOptionsSelectorTests.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { skipWelcomeMessage } from '../../../util/frontendInteractionUtil';
+import { populateFlowcharts } from '../../../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { FLOW_LIST_ITEM_SELECTOR } from 'tests/util/selectorTestUtil';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { FLOW_LIST_ITEM_SELECTOR } from '../../../util/selectorTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
 
 // put these tests here instead of w/ component bc this component uses
 // a lot of stores and setting up state is easier when doing it in an e2e env

--- a/tests/page/flows/search/courseSearchTests.test.ts
+++ b/tests/page/flows/search/courseSearchTests.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from '../../../util/userDataTestUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { dragAndDrop, skipWelcomeMessage } from '../../../util/frontendInteractionUtil';
-import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
+import { dragAndDrop, skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 import {
   TERM_CONTAINER_SELECTOR,
   FLOW_LIST_ITEM_SELECTOR,
   getTermContainerCourseLocator,
   CATALOG_SEARCH_COURSES_SELECTOR
-} from '../../../util/selectorTestUtil';
+} from '$test/util/selectorTestUtil';
 import type { Page } from '@playwright/test';
 import type { CatalogSearchValidFields } from '$lib/server/schema/searchCatalogSchema';
 

--- a/tests/page/flows/search/courseSearchTests.test.ts
+++ b/tests/page/flows/search/courseSearchTests.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { populateFlowcharts } from '../../../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { dragAndDrop, skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { dragAndDrop, skipWelcomeMessage } from '../../../util/frontendInteractionUtil';
+import { getUserEmailString, performLoginFrontend } from '../../../util/userTestUtil';
 import {
   TERM_CONTAINER_SELECTOR,
   FLOW_LIST_ITEM_SELECTOR,
   getTermContainerCourseLocator,
   CATALOG_SEARCH_COURSES_SELECTOR
-} from 'tests/util/selectorTestUtil';
+} from '../../../util/selectorTestUtil';
 import type { Page } from '@playwright/test';
 import type { CatalogSearchValidFields } from '$lib/server/schema/searchCatalogSchema';
 

--- a/tests/page/homePageTests.test.ts
+++ b/tests/page/homePageTests.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { checkCarouselSlide } from 'tests/util/homeCarouselTestUtil';
+import { checkCarouselSlide } from '../util/homeCarouselTestUtil';
 
 test.describe('homepage tests', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/page/homePageTests.test.ts
+++ b/tests/page/homePageTests.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { checkCarouselSlide } from '../util/homeCarouselTestUtil';
+import { checkCarouselSlide } from '$test/util/homeCarouselTestUtil';
 
 test.describe('homepage tests', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/page/loginPageTests.test.ts
+++ b/tests/page/loginPageTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from '../util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 
 test.describe('login page tests', () => {
   let userEmail: string;

--- a/tests/page/loginPageTests.test.ts
+++ b/tests/page/loginPageTests.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../util/userTestUtil';
 
 test.describe('login page tests', () => {
   let userEmail: string;

--- a/tests/page/registerPageTests.test.ts
+++ b/tests/page/registerPageTests.test.ts
@@ -1,6 +1,6 @@
 import { deleteUser } from '$lib/server/db/user';
 import { expect, test } from '@playwright/test';
-import { getUserEmailString } from '../util/userTestUtil';
+import { getUserEmailString } from '$test/util/userTestUtil';
 
 test.describe('registration page tests', () => {
   let userEmail: string;

--- a/tests/page/registerPageTests.test.ts
+++ b/tests/page/registerPageTests.test.ts
@@ -1,6 +1,6 @@
 import { deleteUser } from '$lib/server/db/user';
 import { expect, test } from '@playwright/test';
-import { getUserEmailString } from 'tests/util/userTestUtil';
+import { getUserEmailString } from '../util/userTestUtil';
 
 test.describe('registration page tests', () => {
   let userEmail: string;

--- a/tests/page/resetPasswordPageTests.test.ts
+++ b/tests/page/resetPasswordPageTests.test.ts
@@ -1,8 +1,8 @@
-import { createToken } from 'tests/util/tokenTestUtil';
+import { createToken } from '../util/tokenTestUtil';
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
 import { clearTokensByEmail } from '$lib/server/db/token';
-import { getUserEmailString } from 'tests/util/userTestUtil';
+import { getUserEmailString } from '../util/userTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
 
 test.describe('reset password page tests (no token)', () => {

--- a/tests/page/resetPasswordPageTests.test.ts
+++ b/tests/page/resetPasswordPageTests.test.ts
@@ -1,8 +1,8 @@
-import { createToken } from '../util/tokenTestUtil';
+import { createToken } from '$test/util/tokenTestUtil';
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
 import { clearTokensByEmail } from '$lib/server/db/token';
-import { getUserEmailString } from '../util/userTestUtil';
+import { getUserEmailString } from '$test/util/userTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
 
 test.describe('reset password page tests (no token)', () => {

--- a/tests/routine/createFlowRoutineTests.test.ts
+++ b/tests/routine/createFlowRoutineTests.test.ts
@@ -1,10 +1,10 @@
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
-import { skipWelcomeMessage } from '../util/frontendInteractionUtil';
-import { populateFlowcharts } from '../util/userDataTestUtil';
+import { skipWelcomeMessage } from '$test/util/frontendInteractionUtil';
+import { populateFlowcharts } from '$test/util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { FLOW_LIST_ITEM_SELECTOR } from '../util/selectorTestUtil';
-import { getUserEmailString, performLoginFrontend } from '../util/userTestUtil';
+import { FLOW_LIST_ITEM_SELECTOR } from '$test/util/selectorTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 
 // TODO: is this a "routine", or an "Action"? figure out what routine is and
 // reorganize the tests

--- a/tests/routine/createFlowRoutineTests.test.ts
+++ b/tests/routine/createFlowRoutineTests.test.ts
@@ -1,10 +1,10 @@
 import { PrismaClient } from '@prisma/client';
 import { expect, test } from '@playwright/test';
-import { skipWelcomeMessage } from 'tests/util/frontendInteractionUtil';
-import { populateFlowcharts } from 'tests/util/userDataTestUtil';
+import { skipWelcomeMessage } from '../util/frontendInteractionUtil';
+import { populateFlowcharts } from '../util/userDataTestUtil';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { FLOW_LIST_ITEM_SELECTOR } from 'tests/util/selectorTestUtil';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { FLOW_LIST_ITEM_SELECTOR } from '../util/selectorTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../util/userTestUtil';
 
 // TODO: is this a "routine", or an "Action"? figure out what routine is and
 // reorganize the tests

--- a/tests/routine/resetPasswordRoutineTests.test.ts
+++ b/tests/routine/resetPasswordRoutineTests.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from 'tests/util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '../util/userTestUtil';
 
 test.describe('reset password routine tests', () => {
   test.describe.configure({

--- a/tests/routine/resetPasswordRoutineTests.test.ts
+++ b/tests/routine/resetPasswordRoutineTests.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { PrismaClient } from '@prisma/client';
 import { createUser, deleteUser } from '$lib/server/db/user';
-import { getUserEmailString, performLoginFrontend } from '../util/userTestUtil';
+import { getUserEmailString, performLoginFrontend } from '$test/util/userTestUtil';
 
 test.describe('reset password routine tests', () => {
   test.describe.configure({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,11 +10,11 @@
     "sourceMap": true,
     "strict": true,
     // fixes this issue for Playwright: https://github.com/sveltejs/kit/issues/8742
-    "baseUrl": ".",
-    "paths": {
-      "$lib": ["src/lib"],
-      "$lib/*": ["src/lib/*"]
-    },
+    // "baseUrl": ".",
+    // "paths": {
+    //   "$lib": ["src/lib"],
+    //   "$lib/*": ["src/lib/*"]
+    // },
     "types": ["vitest/globals", "./node_modules/@testing-library/jest-dom/types/vitest"]
   }
   // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,12 +9,6 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    // fixes this issue for Playwright: https://github.com/sveltejs/kit/issues/8742
-    // "baseUrl": ".",
-    // "paths": {
-    //   "$lib": ["src/lib"],
-    //   "$lib/*": ["src/lib/*"]
-    // },
     "types": ["vitest/globals", "./node_modules/@testing-library/jest-dom/types/vitest"]
   }
   // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias


### PR DESCRIPTION
We currently have a variety of utility and other files that reside in the `tests` directory. Previously, for tests (in both the `tests` and `src` directories) to use these files, we needed to use relative paths and/or update the `baseUrl` in `tsconfig.json`.

Since this code was written, SvelteKit added support for path aliases in TypeScript. We migrate to using a `$test` path alias to keep the import of testing-related utilities clean across all test files.

The existing E2E and unit tests are passing with these changes.